### PR TITLE
Fix orphan project folder nodes and skip unsupported project types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 obj
 .DS_Store
 app
+*.DotSettings.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs
 .vscode
+.idea
 bin
 obj
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS sdk
 RUN mkdir -p /src/Stahz
 WORKDIR /src
 COPY Strazh/Strazh.csproj Strazh/Strazh.csproj

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -35,6 +36,100 @@ public class AnalyzerTests
 
         Assert.Contains("Strazh.Tests.ProjectA.csproj", projectFileNames);
         Assert.Contains("Strazh.Tests.ProjectB.csproj", projectFileNames);
+    }
+
+    /// <summary>
+    /// Verifies that the first run with a cache directory (cache miss, binlog written) produces
+    /// the same results as a completely uncached build.
+    /// </summary>
+    [Fact]
+    public async Task GetAnalysisContext_FirstCachedRun_YieldsSameResultsAsUncachedBuild()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var cacheDir = Path.Combine(Path.GetTempPath(), $"strazh-test-{Guid.NewGuid():N}");
+        try
+        {
+            var cachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath), cacheDir);
+
+            var uncachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath));
+
+            AssertAnalysisContextsAreEquivalent(uncachedContext, cachedContext);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that replaying a populated cache (cache hit, binlog replayed) produces the same
+    /// results as a completely uncached build.
+    /// </summary>
+    [Fact]
+    public async Task GetAnalysisContext_CacheHitRun_YieldsSameResultsAsUncachedBuild()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var cacheDir = Path.Combine(Path.GetTempPath(), $"strazh-test-{Guid.NewGuid():N}");
+        try
+        {
+            // Populate the cache
+            await Analyzer.GetAnalysisContext(new AnalyzerManager(solutionPath), cacheDir);
+
+            // Replay from cache
+            var cachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath), cacheDir);
+
+            var uncachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath));
+
+            AssertAnalysisContextsAreEquivalent(uncachedContext, cachedContext);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, recursive: true);
+            }
+        }
+    }
+
+    private static void AssertAnalysisContextsAreEquivalent(
+        Analyzer.AnalysisContext expected, Analyzer.AnalysisContext actual)
+    {
+        var expectedResults = expected.Projects
+            .Select(p => p.Item2)
+            .OrderBy(r => r.ProjectFilePath)
+            .ToList();
+
+        var actualResults = actual.Projects
+            .Select(p => p.Item2)
+            .OrderBy(r => r.ProjectFilePath)
+            .ToList();
+
+        Assert.Equal(expectedResults.Count, actualResults.Count);
+
+        for (var i = 0; i < expectedResults.Count; i++)
+        {
+            var exp = expectedResults[i];
+            var act = actualResults[i];
+
+            Assert.Equal(exp.ProjectFilePath, act.ProjectFilePath);
+            Assert.Equal(exp.Succeeded, act.Succeeded);
+            Assert.Equal(
+                exp.ProjectReferences.OrderBy(x => x).ToList(),
+                act.ProjectReferences.OrderBy(x => x).ToList());
+            Assert.Equal(
+                exp.SourceFiles.OrderBy(x => x).ToList(),
+                act.SourceFiles.OrderBy(x => x).ToList());
+            Assert.Equal(
+                exp.PackageReferences.Keys.OrderBy(x => x).ToList(),
+                act.PackageReferences.Keys.OrderBy(x => x).ToList());
+        }
     }
 
     // [CallerFilePath] gives the compile-time absolute path of this source file.

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Buildalyzer;
+using Strazh.Analysis;
+using Xunit;
+
+namespace Strazh.Tests;
+
+public class AnalyzerTests
+{
+    /// <summary>
+    /// Regression test for the bug where projects pulled into the Roslyn workspace as transitive
+    /// references by an earlier project's AddToWorkspace(workspace, addProjectReferences: true)
+    /// call were subsequently skipped by the deduplication check and never entered
+    /// context.Projects — causing them to receive no CONTAINS triple and no analysis.
+    ///
+    /// The fixture solution (SystemUnderTest.sln) lists ProjectA before ProjectB.
+    /// ProjectA references ProjectB, so when ProjectA is added to the workspace with
+    /// addProjectReferences: true, Buildalyzer pulls ProjectB in as a reference. Without the
+    /// fix, ProjectB's loop iteration finds it already in the workspace and is dropped.
+    /// </summary>
+    [Fact]
+    public void GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var manager = new AnalyzerManager(solutionPath);
+
+        var context = Analyzer.GetAnalysisContext(manager);
+
+        var projectFileNames = context.Projects
+            .Select(p => Path.GetFileName(p.Item2.ProjectFilePath))
+            .ToList();
+
+        Assert.Contains("Strazh.Tests.ProjectA.csproj", projectFileNames);
+        Assert.Contains("Strazh.Tests.ProjectB.csproj", projectFileNames);
+    }
+
+    // [CallerFilePath] gives the compile-time absolute path of this source file.
+    // From Strazh.Tests/AnalyzerTests.cs, two levels up reaches the repo root.
+    private static string GetRepoRoot([CallerFilePath] string callerFile = "") =>
+        Path.GetFullPath(Path.Combine(callerFile, "../.."));
+}

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Buildalyzer;
 using Strazh.Analysis;
 using Xunit;
@@ -21,12 +22,12 @@ public class AnalyzerTests
     /// fix, ProjectB's loop iteration finds it already in the workspace and is dropped.
     /// </summary>
     [Fact]
-    public void GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
+    public async Task GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
     {
         var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
         var manager = new AnalyzerManager(solutionPath);
 
-        var context = Analyzer.GetAnalysisContext(manager);
+        var context = await Analyzer.GetAnalysisContext(manager);
 
         var projectFileNames = context.Projects
             .Select(p => Path.GetFileName(p.Item2.ProjectFilePath))

--- a/Strazh.Tests/Strazh.Tests.csproj
+++ b/Strazh.Tests/Strazh.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strazh\Strazh.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -8,11 +8,9 @@ using Buildalyzer;
 using Buildalyzer.Workspaces;
 using System.Collections.Generic;
 using System;
-using System.Collections.Concurrent;
 using Strazh.Database;
 using static Strazh.Analysis.AnalyzerConfig;
 using System.IO;
-using Microsoft.Build.Construction;
 
 namespace Strazh.Analysis
 {
@@ -31,12 +29,6 @@ namespace Strazh.Analysis
                 : config.Projects.Select(x => manager.GetProject(x))).ToList();
 
             Console.WriteLine($"Analyzer ready to analyze {projectAnalyzers.Count} project/s.");
-            
-            Console.WriteLine("Building workspace...");
-            var context = GetAnalysisContext(manager);
-            Console.WriteLine("done.");
-            
-            Console.WriteLine("Analyzing workspace...");
 
             // Delete graph data upfront before parallel analysis begins, so that no project
             // races against the delete.
@@ -45,80 +37,91 @@ namespace Strazh.Analysis
                 await DbManager.DeleteData(config.Credentials);
             }
 
+            var workspace = CreateWorkspace(manager);
+
             // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
             var semaphore = new SemaphoreSlim(4);
-            var total = context.Projects.Count;
+            var total = projectAnalyzers.Count;
+            var tasks = new List<Task>();
+            var index = 0;
 
-            // Analyze and insert all projects concurrently. Task.Run ensures CPU-bound work
-            // (syntax tree walking) runs on thread-pool threads rather than the calling thread.
-            var tasks = context.Projects.Select((entry, index) => Task.Run(async () =>
+            // Stream projects through the Build → Load pipeline and launch an Analyze + Insert
+            // task for each one as soon as it becomes available, without waiting for all
+            // projects to finish building and loading first.
+            await foreach (var entry in StreamProjectsAsync(manager, workspace))
             {
-                var triples = new List<Triple>();
+                var capturedEntry = entry;
+                var capturedIndex = index++;
 
-                if (config.IsSolutionBased)
+                tasks.Add(Task.Run(async () =>
                 {
-                    var solutionRoot = GetRoot(manager.SolutionFilePath);
-                    var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+                    var triples = new List<Triple>();
 
-                    var solutionName = GetSolutionName(manager.SolutionFilePath);
-                    var solutionNode = new SolutionNode(solutionName);
-                    triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-
-                    var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
-                    triples.Add(new TripleContains(solutionNode, projectNode));
-                }
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - starting");
-                var projectTriples = await AnalyzeProject(index + 1, entry, config.Tier);
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - finished");
-
-                triples.AddRange(projectTriples);
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - starting");
-                try
-                {
-                    triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
-                        .ToList();
-                }
-                catch (Exception)
-                {
-                    Console.WriteLine("Error detected. Dumping detailed logging data.");
-                    Console.WriteLine("[");
-                    var first = true;
-                    foreach (var triple in triples)
+                    if (config.IsSolutionBased)
                     {
-                        if (!first)
+                        var solutionRoot = GetRoot(manager.SolutionFilePath);
+                        var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+
+                        var solutionName = GetSolutionName(manager.SolutionFilePath);
+                        var solutionNode = new SolutionNode(solutionName);
+                        triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
+
+                        var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
+                        triples.Add(new TripleContains(solutionNode, projectNode));
+                    }
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - starting");
+                    var projectTriples = await AnalyzeProject(capturedIndex + 1, capturedEntry, config.Tier);
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - finished");
+
+                    triples.AddRange(projectTriples);
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - starting");
+                    try
+                    {
+                        triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
+                            .ToList();
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine("Error detected. Dumping detailed logging data.");
+                        Console.WriteLine("[");
+                        var first = true;
+                        foreach (var triple in triples)
                         {
-                            Console.WriteLine(",");
+                            if (!first)
+                            {
+                                Console.WriteLine(",");
+                            }
+                            Console.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
+
+                            first = false;
                         }
-                        Console.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
-
-                        first = false;
+                        if (triples.Any())
+                        {
+                            Console.WriteLine("");
+                        }
+                        Console.WriteLine("]");
+                        throw;
                     }
-                    if (triples.Any())
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - finished");
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - starting");
+                    await semaphore.WaitAsync();
+                    try
                     {
-                        Console.WriteLine("");
+                        await DbManager.InsertData(triples, config.Credentials);
                     }
-                    Console.WriteLine("]");
-                    throw;
-                }
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - finished");
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - starting");
-                await semaphore.WaitAsync();
-                try
-                {
-                    await DbManager.InsertData(triples, config.Credentials);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - finished");
-            })).ToList();
+                    finally
+                    {
+                        semaphore.Release();
+                    }
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - finished");
+                }));
+            }
 
             await Task.WhenAll(tasks);
-            context.Workspace.Dispose();
+            workspace.Dispose();
         }
 
         public class AnalysisContext(AdhocWorkspace workspace, List<(Project, IAnalyzerResult)> projects)
@@ -128,71 +131,82 @@ namespace Strazh.Analysis
         }
         
         // Based on https://github.com/phmonte/Buildalyzer/blob/9db3390b49dca033fd3f70439bab3a6327440a47/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs#L24-L60
-        public static AnalysisContext GetAnalysisContext(IAnalyzerManager manager)
+        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager)
         {
             if (manager is null)
             {
                 throw new ArgumentNullException(nameof(manager));
             }
-            
-            var projectResults = new ConcurrentBag<(Project, IAnalyzerResult)>(); 
 
-            Console.WriteLine("Building projects - starting");
-            
-            // Build projects in parallel — each invocation spawns an isolated MSBuild process
-            // so there is no shared mutable state between concurrent builds.
-            List<IAnalyzerResult?> results = manager.Projects.Values
-                .AsParallel()
-                .Select(p =>
-                {
-                    Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
-                    var result = p.Build().FirstOrDefault();
-                    Console.WriteLine($"Building projects - {p.ProjectFile.Name} - finished");
-                    return result;
-                })
-                .Where(x => x != null)
-                .ToList();
-            Console.WriteLine("Building projects - finished.");
-
-            // Create a new workspace and add the solution (if there was one)
-            AdhocWorkspace workspace = new AdhocWorkspace();
-            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+            var workspace = CreateWorkspace(manager);
+            var projects = new List<(Project, IAnalyzerResult)>();
+            await foreach (var item in StreamProjectsAsync(manager, workspace))
             {
-                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
-                workspace.AddSolution(solutionInfo);
-
-                // Sort the projects so the order that they're added to the workspace in the same order as the solution file
-                List<ProjectInSolution> projectsInOrder = [.. manager.SolutionFile.ProjectsInOrder];
-                results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
+                projects.Add(item);
             }
 
-            // Add each result to the new workspace (sorted in solution order above, if we have a solution).
-            // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
-            Console.WriteLine("Loading projects into workspace - starting");
-            foreach (IAnalyzerResult result in results)
+            return new AnalysisContext(workspace, projects);
+        }
+
+        // Launches all MSBuild design-time builds in parallel (Build stage), then as each
+        // completes feeds it sequentially into the Roslyn AdhocWorkspace (Load stage), and
+        // yields the (Project, IAnalyzerResult) pair immediately — without waiting for all
+        // projects to finish first.
+        //
+        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential while
+        // the underlying builds run concurrently on the thread pool.
+        private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
+            IAnalyzerManager manager, AdhocWorkspace workspace)
+        {
+            // Build stage: launch all MSBuild design-time builds concurrently
+            List<Task<IAnalyzerResult?>> buildTasks = manager.Projects.Values
+                .Select(p => Task.Run<IAnalyzerResult?>(() =>
+                {
+                    Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                    var result = p.Build().FirstOrDefault();
+                    Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                    return result;
+                }))
+                .ToList();
+
+            // Load stage: as each build completes, add it to the workspace immediately
+            await foreach (var completedTask in Task.WhenEach(buildTasks))
             {
-                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - starting");
-                var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
+                var result = await completedTask;
+                if (result is null) continue;
+
+                Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");
+                var existingProject = workspace.CurrentSolution.Projects
+                    .FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
                 if (existingProject is null)
                 {
                     // AddToWorkspace with addProjectReferences: true eagerly adds referenced projects
                     // into the workspace. Those will be picked up via existingProject on their own
-                    // loop iteration below.
+                    // iteration below.
                     var project = result.AddToWorkspace(workspace, true);
-                    projectResults.Add((project, result));
+                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
+                    yield return (project, result);
                 }
                 else
                 {
                     // Already in the workspace because an earlier project pulled it in as a
                     // transitive reference. Still include it so it gets CONTAINS triples and
                     // is analyzed — just reuse the workspace Project object already there.
-                    projectResults.Add((existingProject, result));
+                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
+                    yield return (existingProject, result);
                 }
-                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - finished");
             }
-            Console.WriteLine("Loading projects into workspace - finished");
+        }
 
-            return new AnalysisContext(workspace, projectResults.ToList());
+        private static AdhocWorkspace CreateWorkspace(IAnalyzerManager manager)
+        {
+            var workspace = new AdhocWorkspace();
+            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+            {
+                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+                workspace.AddSolution(solutionInfo);
+            }
+            return workspace;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject(int index, (Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -11,6 +11,8 @@ using System;
 using Strazh.Database;
 using static Strazh.Analysis.AnalyzerConfig;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Strazh.Analysis
 {
@@ -48,7 +50,7 @@ namespace Strazh.Analysis
             // Stream projects through the Build → Load pipeline and launch an Analyze + Insert
             // task for each one as soon as it becomes available, without waiting for all
             // projects to finish building and loading first.
-            await foreach (var entry in StreamProjectsAsync(manager, workspace))
+            await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory))
             {
                 var capturedEntry = entry;
                 var capturedIndex = index++;
@@ -131,7 +133,7 @@ namespace Strazh.Analysis
         }
         
         // Based on https://github.com/phmonte/Buildalyzer/blob/9db3390b49dca033fd3f70439bab3a6327440a47/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs#L24-L60
-        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager)
+        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager, string? cacheDirectory = null)
         {
             if (manager is null)
             {
@@ -140,7 +142,7 @@ namespace Strazh.Analysis
 
             var workspace = CreateWorkspace(manager);
             var projects = new List<(Project, IAnalyzerResult)>();
-            await foreach (var item in StreamProjectsAsync(manager, workspace))
+            await foreach (var item in StreamProjectsAsync(manager, workspace, cacheDirectory))
             {
                 projects.Add(item);
             }
@@ -161,8 +163,15 @@ namespace Strazh.Analysis
         //
         // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
-            IAnalyzerManager manager, AdhocWorkspace workspace)
+            IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null)
         {
+            HashSet<string>? projectsNeedingRebuild = null;
+            if (cacheDirectory != null)
+            {
+                Directory.CreateDirectory(cacheDirectory);
+                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+            }
+
             // Build stage: run MSBuild design-time builds in parallel, capped at the number
             // of logical processors so we don't spawn an unbounded number of dotnet processes
             var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
@@ -172,9 +181,33 @@ namespace Strazh.Analysis
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
-                        var result = p.Build().FirstOrDefault();
-                        Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        IAnalyzerResult? result;
+                        if (cacheDirectory != null)
+                        {
+                            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
+                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
+                            {
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                                p.AddBinaryLogger(binlogPath);
+                                result = p.Build().FirstOrDefault();
+                                if (result != null)
+                                {
+                                    WriteDepsFile(binlogPath, result);
+                                }
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                            }
+                            else
+                            {
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - cache hit");
+                                result = manager.Analyze(binlogPath).FirstOrDefault();
+                            }
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                            result = p.Build().FirstOrDefault();
+                            Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        }
                         return result;
                     }
                     finally
@@ -187,7 +220,10 @@ namespace Strazh.Analysis
             // so analysis can begin on each project without waiting for all to be loaded
             foreach (var result in results)
             {
-                if (result is null) continue;
+                if (result is null)
+                {
+                    continue;
+                }
 
                 Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");
                 var existingProject = workspace.CurrentSolution.Projects
@@ -221,6 +257,108 @@ namespace Strazh.Analysis
                 workspace.AddSolution(solutionInfo);
             }
             return workspace;
+        }
+
+        private static string GetBinlogCachePath(string cacheDirectory, IProjectAnalyzer p)
+        {
+            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(p.ProjectFile.Path));
+            var hash = Convert.ToHexString(bytes)[..8];
+            return Path.Combine(cacheDirectory, $"{p.ProjectFile.Name}_{hash}.binlog");
+        }
+
+        // Returns true if no binlog exists, or if the binlog is older than any source or
+        // build file in the project directory (excluding obj/ and bin/ output folders).
+        private static bool IsBinlogStale(string binlogPath, string projectFilePath)
+        {
+            if (!File.Exists(binlogPath))
+            {
+                return true;
+            }
+
+            var binlogTime = File.GetLastWriteTimeUtc(binlogPath);
+
+            if (File.GetLastWriteTimeUtc(projectFilePath) > binlogTime)
+            {
+                return true;
+            }
+
+            var projectDir = Path.GetDirectoryName(projectFilePath)!;
+            var trackedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { ".cs", ".fs", ".vb", ".props", ".targets" };
+
+            foreach (var file in Directory.EnumerateFiles(projectDir, "*", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                    file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                {
+                    continue;
+                }
+
+                if (trackedExtensions.Contains(Path.GetExtension(file)) &&
+                    File.GetLastWriteTimeUtc(file) > binlogTime)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Writes the fully-evaluated project references from a build result as a sidecar next to
+        // the binlog. Subsequent runs read this instead of parsing the project file, so all
+        // MSBuild evaluation (conditions, imports, Directory.Build.props, etc.) is accounted for.
+        private static void WriteDepsFile(string binlogPath, IAnalyzerResult result) =>
+            File.WriteAllLines(binlogPath + ".deps", result.ProjectReferences);
+
+        // Reads the deps sidecar written by a previous build. Returns empty when the file does
+        // not exist (first run, or cache cleared) — the project will be stale for other reasons.
+        private static IReadOnlyList<string> ReadDepsFile(string binlogPath)
+        {
+            var depsPath = binlogPath + ".deps";
+            return File.Exists(depsPath) ? File.ReadAllLines(depsPath) : [];
+        }
+
+        // Determines which projects must be rebuilt, accounting for transitive dependencies:
+        // if project B needs a rebuild and project A references B, A is also marked for rebuild.
+        // The dependency graph is reconstructed from the sidecar files written by previous builds,
+        // so MSBuild's own evaluation (conditions, imports, etc.) is used — not our own parsing.
+        private static HashSet<string> ComputeProjectsNeedingRebuild(
+            IEnumerable<IProjectAnalyzer> projects, string cacheDirectory)
+        {
+            var projectMap = projects.ToDictionary(p => p.ProjectFile.Path, StringComparer.OrdinalIgnoreCase);
+
+            var depGraph = projectMap.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ReadDepsFile(GetBinlogCachePath(cacheDirectory, kvp.Value))
+                    .Where(r => projectMap.ContainsKey(r))
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var needsRebuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (path, analyzer) in projectMap)
+            {
+                if (IsBinlogStale(GetBinlogCachePath(cacheDirectory, analyzer), path))
+                {
+                    needsRebuild.Add(path);
+                }
+            }
+
+            // Propagate: if a referenced project needs a rebuild, so does the referencing project
+            bool changed;
+            do
+            {
+                changed = false;
+                foreach (var (path, refs) in depGraph)
+                {
+                    if (!needsRebuild.Contains(path) && refs.Any(r => needsRebuild.Contains(r)))
+                    {
+                        needsRebuild.Add(path);
+                        changed = true;
+                    }
+                }
+            } while (changed);
+
+            return needsRebuild;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject(int index, (Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -39,8 +39,8 @@ namespace Strazh.Analysis
 
             var workspace = CreateWorkspace(manager);
 
-            // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
-            var semaphore = new SemaphoreSlim(4);
+            // Limit concurrent Neo4j connections to one per logical processor.
+            var semaphore = new SemaphoreSlim(Environment.ProcessorCount);
             var total = projectAnalyzers.Count;
             var tasks = new List<Task>();
             var index = 0;

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -115,7 +115,7 @@ namespace Strazh.Analysis
 
             Console.WriteLine("Building projects - starting");
             
-            List<IAnalyzerResult> results = manager.Projects.Values
+            List<IAnalyzerResult?> results = manager.Projects.Values
                 .Select(p =>
                 {
                     Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
@@ -142,11 +142,21 @@ namespace Strazh.Analysis
             // Add each result to the new workspace (sorted in solution order above, if we have a solution)
             foreach (IAnalyzerResult result in results)
             {
-                // Check for duplicate project files and don't add them
-                if (workspace.CurrentSolution.Projects.All(p => p.FilePath != result.ProjectFilePath))
+                var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
+                if (existingProject is null)
                 {
+                    // AddToWorkspace with addProjectReferences: true eagerly adds referenced projects
+                    // into the workspace. Those will be picked up via existingProject on their own
+                    // loop iteration below.
                     var project = result.AddToWorkspace(workspace, true);
                     projectResults.Add((project, result));
+                }
+                else
+                {
+                    // Already in the workspace because an earlier project pulled it in as a
+                    // transitive reference. Still include it so it gets CONTAINS triples and
+                    // is analyzed — just reuse the workspace Project object already there.
+                    projectResults.Add((existingProject, result));
                 }
             }
 

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -148,31 +148,35 @@ namespace Strazh.Analysis
             return new AnalysisContext(workspace, projects);
         }
 
-        // Launches all MSBuild design-time builds in parallel (Build stage), then as each
-        // completes feeds it sequentially into the Roslyn AdhocWorkspace (Load stage), and
-        // yields the (Project, IAnalyzerResult) pair immediately — without waiting for all
-        // projects to finish first.
+        // Runs all MSBuild design-time builds in parallel (Build stage), waits for all to
+        // complete, then feeds results sequentially into the Roslyn AdhocWorkspace (Load stage),
+        // yielding each (Project, IAnalyzerResult) pair immediately so the Analyze and Insert
+        // stages can begin on each project without waiting for all projects to finish loading.
         //
-        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential while
-        // the underlying builds run concurrently on the thread pool.
+        // Build and Load cannot be interleaved: AddToWorkspace(addProjectReferences: true) calls
+        // analyzer.Build() internally for any referenced project not yet in the workspace. If
+        // other builds are still in-flight when this happens, two concurrent builds of the same
+        // project race and Buildalyzer's environment detection fails. Waiting for all builds to
+        // complete first avoids the race while still streaming Load → Analyze.
+        //
+        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
             IAnalyzerManager manager, AdhocWorkspace workspace)
         {
-            // Build stage: launch all MSBuild design-time builds concurrently
-            List<Task<IAnalyzerResult?>> buildTasks = manager.Projects.Values
-                .Select(p => Task.Run<IAnalyzerResult?>(() =>
+            // Build stage: run all MSBuild design-time builds concurrently and wait for all
+            IAnalyzerResult?[] results = await Task.WhenAll(
+                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(() =>
                 {
                     Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
                     var result = p.Build().FirstOrDefault();
                     Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
                     return result;
-                }))
-                .ToList();
+                })));
 
-            // Load stage: as each build completes, add it to the workspace immediately
-            await foreach (var completedTask in Task.WhenEach(buildTasks))
+            // Load stage: add each completed result to the workspace and yield immediately,
+            // so analysis can begin on each project without waiting for all to be loaded
+            foreach (var result in results)
             {
-                var result = await completedTask;
                 if (result is null) continue;
 
                 Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -163,14 +163,24 @@ namespace Strazh.Analysis
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
             IAnalyzerManager manager, AdhocWorkspace workspace)
         {
-            // Build stage: run all MSBuild design-time builds concurrently and wait for all
+            // Build stage: run MSBuild design-time builds in parallel, capped at the number
+            // of logical processors so we don't spawn an unbounded number of dotnet processes
+            var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
             IAnalyzerResult?[] results = await Task.WhenAll(
-                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(() =>
+                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(async () =>
                 {
-                    Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
-                    var result = p.Build().FirstOrDefault();
-                    Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
-                    return result;
+                    await buildSemaphore.WaitAsync();
+                    try
+                    {
+                        Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                        var result = p.Build().FirstOrDefault();
+                        Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        return result;
+                    }
+                    finally
+                    {
+                        buildSemaphore.Release();
+                    }
                 })));
 
             // Load stage: add each completed result to the workspace and yield immediately,

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
@@ -36,8 +37,21 @@ namespace Strazh.Analysis
             Console.WriteLine("done.");
             
             Console.WriteLine("Analyzing workspace...");
-            
-            for (var index = 0; index < context.Projects.Count; index++)
+
+            // Delete graph data upfront before parallel analysis begins, so that no project
+            // races against the delete.
+            if (config.IsDelete)
+            {
+                await DbManager.DeleteData(config.Credentials);
+            }
+
+            // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
+            var semaphore = new SemaphoreSlim(4);
+            var total = context.Projects.Count;
+
+            // Analyze and insert all projects concurrently. Task.Run ensures CPU-bound work
+            // (syntax tree walking) runs on thread-pool threads rather than the calling thread.
+            var tasks = context.Projects.Select((entry, index) => Task.Run(async () =>
             {
                 var triples = new List<Triple>();
 
@@ -45,28 +59,28 @@ namespace Strazh.Analysis
                 {
                     var solutionRoot = GetRoot(manager.SolutionFilePath);
                     var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
-                    
+
                     var solutionName = GetSolutionName(manager.SolutionFilePath);
                     var solutionNode = new SolutionNode(solutionName);
                     triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-                    
-                    var projectNode = new ProjectNode(GetProjectName(context.Projects[index].Item1.Name));
+
+                    var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
                     triples.Add(new TripleContains(solutionNode, projectNode));
                 }
 
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: analyze - starting");
-                var projectTriples = await AnalyzeProject(index + 1, context.Projects[index], config.Tier);
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: analyze - finished");
-                
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - starting");
+                var projectTriples = await AnalyzeProject(index + 1, entry, config.Tier);
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - finished");
+
                 triples.AddRange(projectTriples);
-                
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: grouping - starting");
+
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - starting");
                 try
                 {
                     triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
                         .ToList();
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     Console.WriteLine("Error detected. Dumping detailed logging data.");
                     Console.WriteLine("[");
@@ -88,12 +102,22 @@ namespace Strazh.Analysis
                     Console.WriteLine("]");
                     throw;
                 }
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: grouping - finished");
-                
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: inserting - starting");
-                await DbManager.InsertData(triples, config.Credentials, config.IsDelete && index == 0);
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: inserting - finished");
-            }
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - finished");
+
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - starting");
+                await semaphore.WaitAsync();
+                try
+                {
+                    await DbManager.InsertData(triples, config.Credentials);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - finished");
+            })).ToList();
+
+            await Task.WhenAll(tasks);
             context.Workspace.Dispose();
         }
 
@@ -115,7 +139,10 @@ namespace Strazh.Analysis
 
             Console.WriteLine("Building projects - starting");
             
+            // Build projects in parallel — each invocation spawns an isolated MSBuild process
+            // so there is no shared mutable state between concurrent builds.
             List<IAnalyzerResult?> results = manager.Projects.Values
+                .AsParallel()
                 .Select(p =>
                 {
                     Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
@@ -139,7 +166,8 @@ namespace Strazh.Analysis
                 results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
             }
 
-            // Add each result to the new workspace (sorted in solution order above, if we have a solution)
+            // Add each result to the new workspace (sorted in solution order above, if we have a solution).
+            // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
             foreach (IAnalyzerResult result in results)
             {
                 var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -168,8 +168,10 @@ namespace Strazh.Analysis
 
             // Add each result to the new workspace (sorted in solution order above, if we have a solution).
             // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
+            Console.WriteLine("Loading projects into workspace - starting");
             foreach (IAnalyzerResult result in results)
             {
+                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - starting");
                 var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
                 if (existingProject is null)
                 {
@@ -186,7 +188,9 @@ namespace Strazh.Analysis
                     // is analyzed — just reuse the workspace Project object already there.
                     projectResults.Add((existingProject, result));
                 }
+                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - finished");
             }
+            Console.WriteLine("Loading projects into workspace - finished");
 
             return new AnalysisContext(workspace, projectResults.ToList());
         }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -68,6 +68,18 @@ namespace Strazh.Analysis
                         var solutionNode = new SolutionNode(solutionName);
                         triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
 
+                        // Connect the project's folder to the solution's root folder so the folder
+                        // hierarchy is traversable from the solution downward. Without this triple,
+                        // project folder nodes are orphans — present in the graph but unreachable
+                        // from the solution folder via INCLUDED_IN traversal.
+                        var projectRoot = capturedEntry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
+                        if (!string.IsNullOrEmpty(projectRoot) &&
+                            !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var projectRootNode = new FolderNode(projectRoot, projectRoot);
+                            triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
+                        }
+
                         var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
                         triples.Add(new TripleContains(solutionNode, projectNode));
                     }
@@ -234,6 +246,13 @@ namespace Strazh.Analysis
                     // into the workspace. Those will be picked up via existingProject on their own
                     // iteration below.
                     var project = result.AddToWorkspace(workspace, true);
+                    if (project is null)
+                    {
+                        // AddToWorkspace returns null for project types not supported by Roslyn
+                        // (e.g. F# projects, native projects). Skip them — they cannot be analyzed.
+                        Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - skipped (unsupported project type)");
+                        continue;
+                    }
                     Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
                     yield return (project, result);
                 }

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace Strazh.Analysis
+﻿using System;
+using System.IO;
+
+namespace Strazh.Analysis
 {
     public class AnalyzerConfig
     {
@@ -35,13 +38,14 @@
         public string Solution { get; }
         public string[] Projects { get; }
         public bool IsDelete { get; }
+        public string? CacheDirectory { get; }
 
         public bool IsSolutionBased => !string.IsNullOrEmpty(Solution);
 
         public bool IsValid => (!string.IsNullOrEmpty(Solution) && Projects.Length == 0)
             || (string.IsNullOrEmpty(Solution) && Projects.Length > 0);
 
-        public AnalyzerConfig(string credentials, string tier, string delete, string solution, string[] projects)
+        public AnalyzerConfig(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
         {
             solution = solution == "none" ? "" : solution;
             Credentials = new CredentialsConfig(credentials);
@@ -49,6 +53,9 @@
             IsDelete = delete != "false";
             Solution = solution;
             Projects = projects ?? new string[] { };
+            CacheDirectory = string.IsNullOrEmpty(cacheDirectory)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "strazh", "cache")
+                : cacheDirectory;
         }
 
         private Tiers MapTier(string mode)

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -11,7 +11,20 @@ namespace Strazh.Database
     {
         private const string CONNECTION = "neo4j://localhost:7687";
 
-        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials, bool isDelete)
+        public static async Task DeleteData(CredentialsConfig credentials)
+        {
+            if (credentials == null)
+            {
+                throw new ArgumentException($"Please, provide credentials.");
+            }
+            Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database...");
+            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
+            await session.RunAsync("MATCH (n) DETACH DELETE n;");
+            Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database complete.");
+        }
+
+        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials)
         {
             if (credentials == null)
             {
@@ -22,12 +35,6 @@ namespace Strazh.Database
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {
-                if (isDelete)
-                {
-                    Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database...");
-                    await session.RunAsync("MATCH (n) DETACH DELETE n;");
-                    Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database complete.");
-                }
                 Console.WriteLine($"Processing {triples.Count} triples...");
                 foreach (var triple in triples)
                 {

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -18,8 +18,8 @@ namespace Strazh.Database
                 throw new ArgumentException($"Please, provide credentials.");
             }
             Console.WriteLine($"Code Knowledge Graph use \"{credentials.Database}\" Neo4j database.");
-            var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
-            var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
+            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {
                 if (isDelete)
@@ -38,11 +38,6 @@ namespace Strazh.Database
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
-            }
-            finally
-            {
-                await session.CloseAsync();
-                await driver.CloseAsync();
             }
         }
     }

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -36,46 +36,26 @@ namespace Strazh.Domain
 
     // Code
 
-    public abstract class CodeNode : Node
+    public abstract class CodeNode(string fullName, string name, string[] modifiers = null) : Node(fullName, name)
     {
-        public CodeNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name)
-        {
-
-            Modifiers = modifiers == null ? "" : string.Join(", ", modifiers);
-        }
-
-        public string Modifiers { get; }
+        public string Modifiers { get; } = modifiers == null ? "" : string.Join(", ", modifiers);
 
         public override string Set(string node)
             => $"{base.Set(node)}{(string.IsNullOrEmpty(Modifiers) ? "" : $", {node}.modifiers = \"{Modifiers}\"")}";
     }
 
-    public abstract class TypeNode : CodeNode
-    {
-        public TypeNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-    }
+    public abstract class TypeNode(string fullName, string name, string[] modifiers = null)
+        : CodeNode(fullName, name, modifiers);
 
-    public class ClassNode : TypeNode
+    public class ClassNode(string fullName, string name, string[] modifiers = null)
+        : TypeNode(fullName, name, modifiers)
     {
-        public ClassNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-
         public override string Label { get; } = "Class";
     }
 
-    public class InterfaceNode : TypeNode
+    public class InterfaceNode(string fullName, string name, string[] modifiers = null)
+        : TypeNode(fullName, name, modifiers)
     {
-        public InterfaceNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-
         public override string Label { get; } = "Interface";
     }
 
@@ -106,19 +86,13 @@ namespace Strazh.Domain
 
     // Structure
 
-    public class FileNode : Node
+    public class FileNode(string fullName, string name) : Node(fullName, name)
     {
-        public FileNode(string fullName, string name)
-            : base(fullName, name) { }
-
         public override string Label { get; } = "File";
     }
 
-    public class FolderNode : Node
+    public class FolderNode(string fullName, string name) : Node(fullName, name)
     {
-        public FolderNode(string fullName, string name)
-            : base(fullName, name) { }
-
         public override string Label { get; } = "Folder";
     }
 
@@ -127,13 +101,10 @@ namespace Strazh.Domain
         public override string Label => "Solution";
     }
 
-    public class ProjectNode : Node
+    public class ProjectNode(string fullName, string name) : Node(fullName, name)
     {
         public ProjectNode(string name)
             : this(name, name) { }
-
-        public ProjectNode(string fullName, string name)
-            : base(fullName, name) { }
 
         public override string Label { get; } = "Project";
     }

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Strazh.Domain
 {
@@ -24,7 +27,17 @@ namespace Strazh.Domain
 
         protected virtual void SetPrimaryKey()
         {
-            Pk = FullName.GetHashCode().ToString();
+            Pk = DeterministicHash(FullName);
+        }
+
+        // string.GetHashCode() is randomized per-process in .NET Core and later, so using it
+        // as a Neo4j pk causes every run to generate different values for the same node,
+        // defeating MERGE and creating duplicate nodes. MD5 gives a stable, collision-resistant
+        // identifier across runs. (This is not a security use — stability is all that matters.)
+        protected static string DeterministicHash(string value)
+        {
+            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(value));
+            return Convert.ToHexString(bytes);
         }
 
         public virtual string Set(string node) => 
@@ -80,7 +93,7 @@ namespace Strazh.Domain
 
         protected override void SetPrimaryKey()
         {
-            Pk = $"{FullName}{Arguments}{ReturnType}".GetHashCode().ToString();
+            Pk = DeterministicHash($"{FullName}{Arguments}{ReturnType}");
         }
     }
 
@@ -127,7 +140,7 @@ namespace Strazh.Domain
 
         protected override void SetPrimaryKey()
         {
-            Pk = $"{FullName}{Version}".GetHashCode().ToString();
+            Pk = DeterministicHash($"{FullName}{Version}");
         }
     }
 }

--- a/Strazh/Domain/Triples.cs
+++ b/Strazh/Domain/Triples.cs
@@ -1,19 +1,12 @@
 namespace Strazh.Domain
 {
-    public abstract class Triple : IInspectable
+    public abstract class Triple(Node nodeA, Node nodeB, Relationship relationship) : IInspectable
     {
-        public Node NodeA { get; set; }
+        public Node NodeA { get; set; } = nodeA;
 
-        public Node NodeB { get; set; }
+        public Node NodeB { get; set; } = nodeB;
 
-        public Relationship Relationship { get; set; }
-
-        protected Triple(Node nodeA, Node nodeB, Relationship relationship)
-        {
-            NodeA = nodeA;
-            NodeB = nodeB;
-            Relationship = relationship;
-        }
+        public Relationship Relationship { get; set; } = relationship;
 
         public override string ToString()
             => $"MERGE (a:{NodeA.Label} {{ pk: \"{NodeA.Pk}\" }}) ON CREATE SET {NodeA.Set("a")} ON MATCH SET {NodeA.Set("a")} MERGE (b:{NodeB.Label} {{ pk: \"{NodeB.Pk}\" }}) ON CREATE SET {NodeB.Set("b")} ON MATCH SET {NodeB.Set("b")} MERGE (a)-[:{Relationship.Type}]->(b);";
@@ -24,23 +17,13 @@ namespace Strazh.Domain
 
     // Structure
 
-    public class TripleDependsOnProject : Triple
-    {
-        public TripleDependsOnProject(
-            ProjectNode projectA,
-            ProjectNode projectB)
-            : base(projectA, projectB, new DependsOnRelationship())
-        { }
-    }
+    public class TripleDependsOnProject(
+        ProjectNode projectA,
+        ProjectNode projectB) : Triple(projectA, projectB, new DependsOnRelationship());
 
-    public class TripleDependsOnPackage : Triple
-    {
-        public TripleDependsOnPackage(
-            ProjectNode projectA,
-            PackageNode packageB)
-            : base(projectA, packageB, new DependsOnRelationship())
-        { }
-    }
+    public class TripleDependsOnPackage(
+        ProjectNode projectA,
+        PackageNode packageB) : Triple(projectA, packageB, new DependsOnRelationship());
 
     public class TripleIncludedIn : Triple
     {
@@ -71,53 +54,27 @@ namespace Strazh.Domain
 
     }
     
-    public class TripleContains : Triple
-    {
-        public TripleContains(
-            SolutionNode solution,
-            ProjectNode project)
-            : base(solution, project, new ContainsRelationship())
-        {
-        }
-    }
+    public class TripleContains(
+        SolutionNode solution,
+        ProjectNode project) : Triple(solution, project, new ContainsRelationship());
 
-    public class TripleDeclaredAt : Triple
-    {
-        public TripleDeclaredAt(
-            TypeNode typeA,
-            FileNode fileB)
-            : base(typeA, fileB, new DeclaredAtRelationship())
-        { }
-    }
+    public class TripleDeclaredAt(
+        TypeNode typeA,
+        FileNode fileB) : Triple(typeA, fileB, new DeclaredAtRelationship());
 
     // Code
 
-    public class TripleInvoke : Triple
-    {
-        public TripleInvoke(
-            MethodNode methodA,
-            MethodNode methodB)
-            : base(methodA, methodB, new InvokeRelationship())
-        { }
-    }
+    public class TripleInvoke(
+        MethodNode methodA,
+        MethodNode methodB) : Triple(methodA, methodB, new InvokeRelationship());
 
-    public class TripleHave : Triple
-    {
-        public TripleHave(
-            TypeNode typeA,
-            MethodNode methodB)
-            : base(typeA, methodB, new HaveRelationship())
-        { }
-    }
+    public class TripleHave(
+        TypeNode typeA,
+        MethodNode methodB) : Triple(typeA, methodB, new HaveRelationship());
 
-    public class TripleConstruct : Triple
-    {
-        public TripleConstruct(
-            MethodNode methodA,
-            ClassNode classB)
-            : base(methodA, classB, new ConstructRelationship())
-        { }
-    }
+    public class TripleConstruct(
+        MethodNode methodA,
+        ClassNode classB) : Triple(methodA, classB, new ConstructRelationship());
 
     public class TripleOfType : Triple
     {

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -45,6 +45,12 @@ namespace Strazh
             };
             rootCommand.Options.Add(optionProjects);
 
+            var optionCache = new Option<string>("--cache")
+            {
+                Description = "optional path to a directory where MSBuild binary logs are cached; defaults to the platform application data folder (e.g. ~/Library/Application Support/strazh/cache on macOS)"
+            };
+            rootCommand.Options.Add(optionCache);
+
             rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
             {
                 await BuildKnowledgeGraph(
@@ -52,13 +58,14 @@ namespace Strazh
                     parseResult.GetValue(optionMode),
                     parseResult.GetValue(optionDelete),
                     parseResult.GetValue(optionSolution),
-                    parseResult.GetValue(optionProjects));
+                    parseResult.GetValue(optionProjects),
+                    parseResult.GetValue(optionCache));
             });
 
             return await rootCommand.Parse(args).InvokeAsync();
         }
 
-        private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects)
+        private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
         {
             try
             {
@@ -67,7 +74,8 @@ namespace Strazh
                        tier,
                        delete,
                        solution,
-                       projects
+                       projects,
+                       cacheDirectory
                    );
                 if (!config.IsValid)
                 {

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -1,53 +1,61 @@
-﻿using System;
+using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using Microsoft.Build.Logging.StructuredLogger;
+using System.Threading;
+using System.Threading.Tasks;
 using Strazh.Analysis;
-using Task = System.Threading.Tasks.Task;
 
 namespace Strazh
 {
     public class Program
     {
 
-        public static async Task Main(params string[] args)
+        public static async Task<int> Main(params string[] args)
         {
-#if DEBUG
-            // There is an issue with using Neo4j.Driver 4.2.0
-            // System.IO.FileNotFoundException: Could not load file or assembly '4.2.37.0'. The system cannot find the file specified.
-            // Workaround to load assembly and avoid issue 
-            System.Reflection.Assembly.Load("Neo4j.Driver");
-#endif
             var rootCommand = new RootCommand();
 
-            var optionCredentials = new Option<string>("--credentials", "required information in format `dbname:user:password` to connect to Neo4j Database");
-            optionCredentials.AddAlias("-c");
-            optionCredentials.IsRequired = true;
-            rootCommand.Add(optionCredentials);
+            var optionCredentials = new Option<string>("--credentials", "-c")
+            {
+                Description = "required information in format `dbname:user:password` to connect to Neo4j Database",
+                Required = true
+            };
+            rootCommand.Options.Add(optionCredentials);
 
-            var optionMode = new Option<string>("--tier", "optional flag as `project` or `code` or 'all' (default `all`) selected tier to scan in a codebase");
-            optionMode.AddAlias("-t");
-            optionMode.IsRequired = false;
-            rootCommand.Add(optionMode);
+            var optionMode = new Option<string>("--tier", "-t")
+            {
+                Description = "optional flag as `project` or `code` or 'all' (default `all`) selected tier to scan in a codebase"
+            };
+            rootCommand.Options.Add(optionMode);
 
-            var optionDelete = new Option<string>("--delete", "optional flag as `true` or `false` or no flag (default `true`) to delete data in graph before execution");
-            optionDelete.AddAlias("-d");
-            optionDelete.IsRequired = false;
-            rootCommand.Add(optionDelete);
+            var optionDelete = new Option<string>("--delete", "-d")
+            {
+                Description = "optional flag as `true` or `false` or no flag (default `true`) to delete data in graph before execution"
+            };
+            rootCommand.Options.Add(optionDelete);
 
-            var optionSolution = new Option<string>("--solution", "optional absolute path to only one `.sln` file (can't be used together with -p / --projects)");
-            optionSolution.AddAlias("-s");
-            optionSolution.IsRequired = false;
-            rootCommand.Add(optionSolution);
+            var optionSolution = new Option<string>("--solution", "-s")
+            {
+                Description = "optional absolute path to only one `.sln` file (can't be used together with -p / --projects)"
+            };
+            rootCommand.Options.Add(optionSolution);
 
-            var optionProjects = new Option<string[]>("--projects", "optional list of absolute path to one or many `.csproj` files (can't be used together with -s / --solution)");
-            optionProjects.AddAlias("-p");
-            optionProjects.IsRequired = false;
-            rootCommand.Add(optionProjects);
+            var optionProjects = new Option<string[]>("--projects", "-p")
+            {
+                Description = "optional list of absolute path to one or many `.csproj` files (can't be used together with -s / --solution)",
+                AllowMultipleArgumentsPerToken = true
+            };
+            rootCommand.Options.Add(optionProjects);
 
-            rootCommand.SetHandler(BuildKnowledgeGraph, optionCredentials, optionMode, optionDelete, optionSolution, optionProjects);
+            rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
+            {
+                await BuildKnowledgeGraph(
+                    parseResult.GetValue(optionCredentials),
+                    parseResult.GetValue(optionMode),
+                    parseResult.GetValue(optionDelete),
+                    parseResult.GetValue(optionSolution),
+                    parseResult.GetValue(optionProjects));
+            });
 
-            await rootCommand.InvokeAsync(args);
+            return await rootCommand.Parse(args).InvokeAsync();
         }
 
         private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects)
@@ -73,7 +81,7 @@ namespace Strazh
                     return;
                 }
 
-                Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");                
+                Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");
                 await Analyzer.Analyze(config);
                 Console.WriteLine("Code Knowledge Graph created.");
             }

--- a/Strazh/Strazh.csproj
+++ b/Strazh/Strazh.csproj
@@ -2,19 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.0.0-beta.1</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="7.1.0" />
-    <PackageReference Include="Buildalyzer.Workspaces" Version="7.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="4.13.0" />
-    <PackageReference Include="Neo4j.Driver" Version="5.27.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Buildalyzer" Version="8.0.0" />
+    <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
+    <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Strazh/Strazh.sln
+++ b/Strazh/Strazh.sln
@@ -17,24 +17,66 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectB", "..
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{EF685B52-D0F9-4350-9956-90CF2DE13610}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests", "..\Strazh.Tests\Strazh.Tests.csproj", "{267F7E5F-419B-434D-B9C0-27A12FC95B77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x64.Build.0 = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x86.Build.0 = Release|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x86.Build.0 = Debug|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x64.Build.0 = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x86.Build.0 = Release|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x86.Build.0 = Debug|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x64.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x86.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x64.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x86.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x64.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x64.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x86.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SystemUnderTest/SystemUnderTest.sln
+++ b/SystemUnderTest/SystemUnderTest.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectA", "Strazh.Tests.ProjectA\Strazh.Tests.ProjectA.csproj", "{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectB", "Strazh.Tests.ProjectB\Strazh.Tests.ProjectB.csproj", "{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   strazh:
@@ -7,7 +6,7 @@ services:
     container_name: strazh
     network_mode: host
     volumes:
-      - C:\src\github\strazh\SystemUnderTest:/dest
+      - ./SystemUnderTest:/dest
     environment:
       - c=neo4j:neo4j:strazhpass
       - p=/dest/Strazh.Tests.ProjectB/Strazh.Tests.ProjectB.csproj /dest/Strazh.Tests.ProjectA/Strazh.Tests.ProjectA.csproj
@@ -15,7 +14,7 @@ services:
       - neo4j
 
   neo4j:
-    image: neo4j:4.2.0
+    image: neo4j:2026.03.1
     container_name: strazh_neo4j
     restart: unless-stopped
     ports:
@@ -23,8 +22,8 @@ services:
       - 7687:7687
     environment:
       NEO4J_AUTH: neo4j/strazhpass
-      NEO4J_dbms_memory_pagecache_size: 1G
-      NEO4J_dbms.memory.heap.initial_size: 1G
-      NEO4J_dbms_memory_heap_max__size: 1G
-      NEO4JLABS_PLUGINS: "[\"apoc\",\"graph-data-science\"]"
+      NEO4J_server_memory_pagecache_size: 1G
+      NEO4J_server_memory_heap_initial__size: 1G
+      NEO4J_server_memory_heap_max__size: 1G
+      NEO4J_PLUGINS: "[\"apoc\",\"graph-data-science\"]"
       


### PR DESCRIPTION
## Summary

- **Unsupported project types crash silently**: `result.AddToWorkspace(workspace, true)` returns `null` for project types Roslyn doesn't support (e.g. F# or native projects). The null was yielded into `Analyze` where accessing `Project.Name` on it threw `NullReferenceException`, silently dropping the task and all its triples — including the folder node for that project. Unsupported project types are now detected, logged, and skipped cleanly.
- **Project folder nodes were orphans**: For solution-based analysis, project folder nodes (e.g. `FolderNode("SomeProject")`) were created and connected to their `ProjectNode` via `INCLUDED_IN`, but had no edge pointing up to the solution's root folder (e.g. `FolderNode("infra-dotnet-previews")`). They appeared in the graph but were unreachable via folder hierarchy traversal from the solution. A new `TripleIncludedIn(projectRootNode, solutionRootNode)` triple now connects each project folder to the solution's root folder.

## Dependencies

This PR depends on the following PRs (which must be merged first):
- #13 — Upgrade all dependencies to latest versions, migrate to .NET 10
- #14 — Fix projects dropped when added as transitive references
- #15 — Parallelize MSBuild, Roslyn analysis, and Neo4j inserts across projects
- #16 — Stream projects through pipeline stages without waiting for all to complete
- #17 — Fix non-deterministic node pks causing duplicate nodes across runs
- #18 — Add MSBuild binary log caching to skip rebuilds when nothing has changed

## Test plan

- [ ] Run against a solution containing only C# projects and verify all project folder nodes appear in the graph connected to the solution root folder
- [ ] Run against a solution containing mixed project types (if available) and verify unsupported projects are skipped with a log message and do not crash the run
- [ ] Query Neo4j: `MATCH (f:Folder)<-[:INCLUDED_IN]-(p:Project) RETURN f, p` — verify every project has a folder
- [ ] Query Neo4j: `MATCH (f1:Folder)<-[:INCLUDED_IN]-(f2:Folder) RETURN f1, f2` — verify project folders are connected to the solution root folder

🤖 Generated with [Claude Code](https://claude.com/claude-code)