### PR TITLE
Detect submodule references and stop misattributing submodule folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin
 obj
 .DS_Store
 app
+*.DotSettings.user

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vs
 .vscode
+.idea
 bin
 obj
 .DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:9.0-alpine AS sdk
+FROM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS sdk
 RUN mkdir -p /src/Stahz
 WORKDIR /src
 COPY Strazh/Strazh.csproj Strazh/Strazh.csproj

--- a/Strazh.Tests/AnalyzerSubmoduleTests.cs
+++ b/Strazh.Tests/AnalyzerSubmoduleTests.cs
@@ -1,0 +1,168 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Strazh.Analysis;
+using Strazh.Domain;
+using Xunit;
+
+namespace Strazh.Tests;
+
+/// <summary>
+/// Verifies that Analyzer.Analyze emits the new submodule-mount-point triples when
+/// the host repo's .gitmodules declares submodules. Builds a temp fixture by copying
+/// SystemUnderTest into a scratch directory and stamping a fake git layout
+/// (.git/config + .gitmodules) on top — that way Analyze runs against a real
+/// solution but a controllable git state.
+/// </summary>
+public class AnalyzerSubmoduleTests
+{
+    [Fact]
+    public async Task Analyze_HostWithGitmodules_EmitsSubmoduleMountFolderAndRepositoryLink()
+    {
+        using var fixture = new SolutionFixture(
+            originUrl: "https://github.com/TestOrg/host-repo.git",
+            gitmodules: """
+                [submodule "Core"]
+                    path = Core
+                    url = ../core-repo.git
+                """);
+
+        var store = new InMemoryTripleStore();
+        await Analyzer.Analyze(
+            new AnalyzerConfig(new AnalyzerConfig.Options(
+                Credentials: "",
+                Tier: "project",
+                Delete: "false",
+                Solution: fixture.SolutionPath,
+                Projects: Array.Empty<string>())),
+            NullAnalysisProgress.Instance,
+            store);
+
+        var triples = store.Triples;
+
+        // A Submodule-kind Folder exists at "<host-repo-folder>/Core".
+        var mountFolder = triples
+            .Select(t => t.NodeA)
+            .OfType<FolderNode>()
+            .Concat(triples.Select(t => t.NodeB).OfType<FolderNode>())
+            .FirstOrDefault(f => f.Kind == FolderKind.Submodule && f.Name == "Core");
+        Assert.NotNull(mountFolder);
+        Assert.Equal("host-repo/Core", mountFolder.FullName);
+
+        // It's INCLUDED_IN the referenced Repository (the submodule's resolved owner/repo).
+        Assert.Contains(triples, t =>
+            t.NodeA is FolderNode a && a.Pk == mountFolder.Pk
+            && t.NodeB is RepositoryNode r && r.FullName == "TestOrg/core-repo"
+            && t.Relationship.Type == "INCLUDED_IN");
+
+        // It's also INCLUDED_IN the host's repo-root folder, so the host's tree can
+        // reach the mount point via folder traversal.
+        Assert.Contains(triples, t =>
+            t.NodeA is FolderNode a && a.Pk == mountFolder.Pk
+            && t.NodeB is FolderNode b && b.Name == "host-repo" && b.Kind == FolderKind.Regular
+            && t.Relationship.Type == "INCLUDED_IN");
+    }
+
+    [Fact]
+    public async Task Analyze_HostWithoutGitmodules_EmitsNoSubmoduleKindFolders()
+    {
+        using var fixture = new SolutionFixture(
+            originUrl: "https://github.com/TestOrg/host-repo.git",
+            gitmodules: null);
+
+        var store = new InMemoryTripleStore();
+        await Analyzer.Analyze(
+            new AnalyzerConfig(new AnalyzerConfig.Options(
+                Credentials: "",
+                Tier: "project",
+                Delete: "false",
+                Solution: fixture.SolutionPath,
+                Projects: Array.Empty<string>())),
+            NullAnalysisProgress.Instance,
+            store);
+
+        var anySubmoduleFolder = store.Triples
+            .Select(t => t.NodeA)
+            .Concat(store.Triples.Select(t => t.NodeB))
+            .OfType<FolderNode>()
+            .Any(f => f.Kind == FolderKind.Submodule);
+
+        Assert.False(anySubmoduleFolder);
+    }
+
+    /// <summary>
+    /// Copies the checked-in SystemUnderTest fixture to a scratch directory and stamps
+    /// a fake .git layout on top (config with origin URL, optional .gitmodules).
+    /// Exposes the path to the copied .sln so tests can run Analyze against a
+    /// controllable git state without touching the real repository.
+    /// </summary>
+    private sealed class SolutionFixture : IDisposable
+    {
+        public string Root { get; }
+        public string SolutionPath { get; }
+
+        public SolutionFixture(string originUrl, string? gitmodules)
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"strazh-fixture-{Guid.NewGuid():N}");
+            // Copy SystemUnderTest contents under a "host-repo" subdir so the git root
+            // basename matches what the host repo's name would naturally produce.
+            var hostRepo = Path.Combine(Root, "host-repo");
+            var sourceFixture = Path.Combine(GetThisDir(), "..", "SystemUnderTest");
+            CopyDirectory(sourceFixture, hostRepo);
+
+            // Fake .git/config with the requested origin URL.
+            Directory.CreateDirectory(Path.Combine(hostRepo, ".git"));
+            File.WriteAllText(
+                Path.Combine(hostRepo, ".git", "config"),
+                $"[remote \"origin\"]\n\turl = {originUrl}\n");
+
+            if (gitmodules != null)
+            {
+                File.WriteAllText(Path.Combine(hostRepo, ".gitmodules"), gitmodules);
+            }
+
+            SolutionPath = Path.Combine(hostRepo, "SystemUnderTest.sln");
+        }
+
+        public void Dispose()
+        {
+            if (!Directory.Exists(Root))
+            {
+                return;
+            }
+            try
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup.
+            }
+        }
+
+        private static void CopyDirectory(string source, string destination)
+        {
+            Directory.CreateDirectory(destination);
+            foreach (var dir in Directory.EnumerateDirectories(source, "*", SearchOption.AllDirectories))
+            {
+                Directory.CreateDirectory(dir.Replace(source, destination));
+            }
+            foreach (var file in Directory.EnumerateFiles(source, "*", SearchOption.AllDirectories))
+            {
+                // Skip bin/obj — these contain build outputs that will be regenerated
+                // and can cause path-length / permission issues during copy.
+                if (file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                    || file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
+                {
+                    continue;
+                }
+                File.Copy(file, file.Replace(source, destination), overwrite: true);
+            }
+        }
+
+        private static string GetThisDir([CallerFilePath] string callerFile = "")
+            => Path.GetDirectoryName(callerFile)!;
+    }
+}

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -35,6 +36,100 @@ public class AnalyzerTests
 
         Assert.Contains("Strazh.Tests.ProjectA.csproj", projectFileNames);
         Assert.Contains("Strazh.Tests.ProjectB.csproj", projectFileNames);
+    }
+
+    /// <summary>
+    /// Verifies that the first run with a cache directory (cache miss, binlog written) produces
+    /// the same results as a completely uncached build.
+    /// </summary>
+    [Fact]
+    public async Task GetAnalysisContext_FirstCachedRun_YieldsSameResultsAsUncachedBuild()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var cacheDir = Path.Combine(Path.GetTempPath(), $"strazh-test-{Guid.NewGuid():N}");
+        try
+        {
+            var cachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath), cacheDir);
+
+            var uncachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath));
+
+            AssertAnalysisContextsAreEquivalent(uncachedContext, cachedContext);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, recursive: true);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that replaying a populated cache (cache hit, binlog replayed) produces the same
+    /// results as a completely uncached build.
+    /// </summary>
+    [Fact]
+    public async Task GetAnalysisContext_CacheHitRun_YieldsSameResultsAsUncachedBuild()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var cacheDir = Path.Combine(Path.GetTempPath(), $"strazh-test-{Guid.NewGuid():N}");
+        try
+        {
+            // Populate the cache
+            await Analyzer.GetAnalysisContext(new AnalyzerManager(solutionPath), cacheDir);
+
+            // Replay from cache
+            var cachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath), cacheDir);
+
+            var uncachedContext = await Analyzer.GetAnalysisContext(
+                new AnalyzerManager(solutionPath));
+
+            AssertAnalysisContextsAreEquivalent(uncachedContext, cachedContext);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheDir))
+            {
+                Directory.Delete(cacheDir, recursive: true);
+            }
+        }
+    }
+
+    private static void AssertAnalysisContextsAreEquivalent(
+        Analyzer.AnalysisContext expected, Analyzer.AnalysisContext actual)
+    {
+        var expectedResults = expected.Projects
+            .Select(p => p.Item2)
+            .OrderBy(r => r.ProjectFilePath)
+            .ToList();
+
+        var actualResults = actual.Projects
+            .Select(p => p.Item2)
+            .OrderBy(r => r.ProjectFilePath)
+            .ToList();
+
+        Assert.Equal(expectedResults.Count, actualResults.Count);
+
+        for (var i = 0; i < expectedResults.Count; i++)
+        {
+            var exp = expectedResults[i];
+            var act = actualResults[i];
+
+            Assert.Equal(exp.ProjectFilePath, act.ProjectFilePath);
+            Assert.Equal(exp.Succeeded, act.Succeeded);
+            Assert.Equal(
+                exp.ProjectReferences.OrderBy(x => x).ToList(),
+                act.ProjectReferences.OrderBy(x => x).ToList());
+            Assert.Equal(
+                exp.SourceFiles.OrderBy(x => x).ToList(),
+                act.SourceFiles.OrderBy(x => x).ToList());
+            Assert.Equal(
+                exp.PackageReferences.Keys.OrderBy(x => x).ToList(),
+                act.PackageReferences.Keys.OrderBy(x => x).ToList());
+        }
     }
 
     // [CallerFilePath] gives the compile-time absolute path of this source file.

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Buildalyzer;
 using Strazh.Analysis;
+using Strazh.Domain;
 using Xunit;
 
 namespace Strazh.Tests;
@@ -130,6 +131,44 @@ public class AnalyzerTests
                 exp.PackageReferences.Keys.OrderBy(x => x).ToList(),
                 act.PackageReferences.Keys.OrderBy(x => x).ToList());
         }
+    }
+
+    /// <summary>
+    /// Verifies that analyzing a solution creates a Repository node and the
+    /// Folder(repoShortName) -INCLUDED_IN-> Repository(owner/repo) triple.
+    ///
+    /// The expected repository name is read from the git remote "origin" of the
+    /// containing repository, so the test passes unchanged on both the upstream
+    /// repo (vladbatushkov/strazh) and any fork (e.g. mscottford/strazh).
+    /// </summary>
+    [Fact]
+    public async Task Analyze_CreatesRepositoryNodeAndFolderIncludedInTriple()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var config = new AnalyzerConfig(new AnalyzerConfig.Options(
+            Credentials: "",
+            Tier: "project",
+            Delete: "false",
+            Solution: solutionPath,
+            Projects: Array.Empty<string>()
+        ));
+        var store = new InMemoryTripleStore();
+
+        await Analyzer.Analyze(config, NullAnalysisProgress.Instance, store);
+
+        var triples = store.Triples;
+
+        var expectedRepoName = GitHelper.GetRepositoryName(solutionPath);
+        Assert.NotNull(expectedRepoName);
+
+        var expectedFolderName = expectedRepoName.Split('/').Last();
+
+        var repoTriple = triples.FirstOrDefault(t =>
+            t.NodeA is FolderNode folder && folder.Name == expectedFolderName &&
+            t.NodeB is RepositoryNode repo && repo.FullName == expectedRepoName &&
+            t.Relationship.Type == "INCLUDED_IN");
+
+        Assert.NotNull(repoTriple);
     }
 
     // [CallerFilePath] gives the compile-time absolute path of this source file.

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,0 +1,43 @@
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Buildalyzer;
+using Strazh.Analysis;
+using Xunit;
+
+namespace Strazh.Tests;
+
+public class AnalyzerTests
+{
+    /// <summary>
+    /// Regression test for the bug where projects pulled into the Roslyn workspace as transitive
+    /// references by an earlier project's AddToWorkspace(workspace, addProjectReferences: true)
+    /// call were subsequently skipped by the deduplication check and never entered
+    /// context.Projects — causing them to receive no CONTAINS triple and no analysis.
+    ///
+    /// The fixture solution (SystemUnderTest.sln) lists ProjectA before ProjectB.
+    /// ProjectA references ProjectB, so when ProjectA is added to the workspace with
+    /// addProjectReferences: true, Buildalyzer pulls ProjectB in as a reference. Without the
+    /// fix, ProjectB's loop iteration finds it already in the workspace and is dropped.
+    /// </summary>
+    [Fact]
+    public void GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
+    {
+        var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
+        var manager = new AnalyzerManager(solutionPath);
+
+        var context = Analyzer.GetAnalysisContext(manager);
+
+        var projectFileNames = context.Projects
+            .Select(p => Path.GetFileName(p.Item2.ProjectFilePath))
+            .ToList();
+
+        Assert.Contains("Strazh.Tests.ProjectA.csproj", projectFileNames);
+        Assert.Contains("Strazh.Tests.ProjectB.csproj", projectFileNames);
+    }
+
+    // [CallerFilePath] gives the compile-time absolute path of this source file.
+    // From Strazh.Tests/AnalyzerTests.cs, two levels up reaches the repo root.
+    private static string GetRepoRoot([CallerFilePath] string callerFile = "") =>
+        Path.GetFullPath(Path.Combine(callerFile, "../.."));
+}

--- a/Strazh.Tests/AnalyzerTests.cs
+++ b/Strazh.Tests/AnalyzerTests.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Buildalyzer;
 using Strazh.Analysis;
 using Xunit;
@@ -21,12 +22,12 @@ public class AnalyzerTests
     /// fix, ProjectB's loop iteration finds it already in the workspace and is dropped.
     /// </summary>
     [Fact]
-    public void GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
+    public async Task GetAnalysisContext_IncludesProjectsAddedAsTransitiveReferences()
     {
         var solutionPath = Path.Combine(GetRepoRoot(), "SystemUnderTest", "SystemUnderTest.sln");
         var manager = new AnalyzerManager(solutionPath);
 
-        var context = Analyzer.GetAnalysisContext(manager);
+        var context = await Analyzer.GetAnalysisContext(manager);
 
         var projectFileNames = context.Projects
             .Select(p => Path.GetFileName(p.Item2.ProjectFilePath))

--- a/Strazh.Tests/FolderNodeTests.cs
+++ b/Strazh.Tests/FolderNodeTests.cs
@@ -1,0 +1,46 @@
+using Strazh.Domain;
+using Xunit;
+
+namespace Strazh.Tests;
+
+public class FolderNodeTests
+{
+    /// <summary>
+    /// Two folders sharing a path but differing in <see cref="FolderKind"/> must be
+    /// distinct graph nodes. A Submodule mount-point at <c>host/Core</c> and a
+    /// hypothetical Regular folder at the same path must not collide on MERGE.
+    /// </summary>
+    [Fact]
+    public void Pk_DiffersByKindWhenFullNameMatches()
+    {
+        var regular = new FolderNode("host/Core", "Core");
+        var submodule = new FolderNode("host/Core", "Core", FolderKind.Submodule);
+
+        Assert.NotEqual(regular.Pk, submodule.Pk);
+    }
+
+    [Fact]
+    public void Pk_StableAcrossInstancesForSameInputs()
+    {
+        var a = new FolderNode("host/Core", "Core", FolderKind.Submodule);
+        var b = new FolderNode("host/Core", "Core", FolderKind.Submodule);
+
+        Assert.Equal(a.Pk, b.Pk);
+    }
+
+    [Fact]
+    public void Set_OmitsKindForRegularFolders()
+    {
+        var folder = new FolderNode("foo", "foo");
+
+        Assert.DoesNotContain("kind", folder.Set("f"));
+    }
+
+    [Fact]
+    public void Set_WritesSubmoduleKindLiteral()
+    {
+        var folder = new FolderNode("host/Core", "Core", FolderKind.Submodule);
+
+        Assert.Contains("f.kind = \"Submodule\"", folder.Set("f"));
+    }
+}

--- a/Strazh.Tests/GitHelperIntegrationTests.cs
+++ b/Strazh.Tests/GitHelperIntegrationTests.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Diagnostics;
+using System.IO;
+using Strazh.Analysis;
+using Xunit;
+
+namespace Strazh.Tests;
+
+/// <summary>
+/// End-to-end tests that exercise <see cref="GitHelper"/> against a real submodule
+/// checkout produced by the <c>git</c> CLI: two bare repos are created in a temp
+/// location, one declares the other as a submodule via a relative URL, and the
+/// parent is cloned recursively. The resulting layout (a <c>.git</c> file inside the
+/// submodule that points at <c>.git/modules/&lt;name&gt;/</c> on the parent) is what
+/// the helper has to navigate in production — these tests verify that navigation
+/// against the actual format git emits rather than a hand-crafted approximation.
+///
+/// Requires <c>git</c> on PATH (version recent enough to support
+/// <c>--initial-branch</c> and <c>protocol.file.allow</c>).
+/// </summary>
+public class GitHelperIntegrationTests
+{
+    [Fact]
+    public void RealSubmoduleCheckout_FullAttributionAndResolution()
+    {
+        using var ws = new GitWorkspace();
+
+        // Two bare repos under an Org/ directory so relative URL resolution produces
+        // a sensible owner/repo-shaped name when parsed.
+        var bareCore = ws.InitBare("Org/infra-dotnet-core.git");
+        var bareParent = ws.InitBare("Org/infra-dotnet-personalize.git");
+
+        // Seed the core repo with one commit so it can be added as a submodule.
+        var coreSeed = ws.Clone(bareCore, "core-seed");
+        ws.Write(coreSeed, "README.md", "core");
+        ws.Git(coreSeed, "add", "README.md");
+        ws.Git(coreSeed, "commit", "-m", "init");
+        ws.Git(coreSeed, "push", "origin", "HEAD:refs/heads/main");
+
+        // Seed the parent with one commit, then add core as a submodule via a relative
+        // URL. The parent's origin URL is the file:// path of bareParent, so
+        // ../infra-dotnet-core.git resolves to bareCore — matching real-world git
+        // semantics where submodule URLs are stored relative to the host's origin.
+        var parentSeed = ws.Clone(bareParent, "parent-seed");
+        ws.Write(parentSeed, "README.md", "parent");
+        ws.Git(parentSeed, "add", "README.md");
+        ws.Git(parentSeed, "commit", "-m", "init");
+        ws.Git(parentSeed, "-c", "protocol.file.allow=always",
+            "submodule", "add", "../infra-dotnet-core.git", "Core");
+        ws.Git(parentSeed, "commit", "-m", "add Core submodule");
+        ws.Git(parentSeed, "push", "origin", "HEAD:refs/heads/main");
+
+        // Final clone with submodules populated — this is the layout the helper sees
+        // in production.
+        var final = ws.CloneRecursive(bareParent, "final");
+
+        // The submodule's .git is a file, not a directory — this is the case the
+        // FindGitRoot fix has to handle for paths inside a submodule.
+        var submoduleDotGit = Path.Combine(final, "Core", ".git");
+        Assert.True(File.Exists(submoduleDotGit), ".git inside the submodule must be a file");
+        Assert.False(Directory.Exists(submoduleDotGit), ".git inside the submodule must not be a directory");
+
+        // FindGitRoot stops at the submodule root for paths inside it, and at the
+        // parent for paths outside.
+        Assert.Equal(
+            Path.Combine(final, "Core"),
+            GitHelper.FindGitRoot(Path.Combine(final, "Core", "README.md")));
+        Assert.Equal(
+            final,
+            GitHelper.FindGitRoot(Path.Combine(final, "README.md")));
+
+        // GetRepositoryName follows the .git gitdir pointer into the parent's
+        // .git/modules/Core/config — returning the submodule's own origin URL,
+        // NOT the parent's. This is the attribution invariant the production code
+        // depends on so submodule projects aren't tied to the host repo.
+        var subRepo = GitHelper.GetRepositoryName(Path.Combine(final, "Core", "README.md"));
+        var parentRepo = GitHelper.GetRepositoryName(Path.Combine(final, "README.md"));
+        Assert.NotNull(subRepo);
+        Assert.NotNull(parentRepo);
+        Assert.NotEqual(parentRepo, subRepo);
+        Assert.EndsWith("Org/infra-dotnet-core", subRepo);
+        Assert.EndsWith("Org/infra-dotnet-personalize", parentRepo);
+
+        // GetSubmodules reads .gitmodules from the parent and resolves the relative
+        // url ../infra-dotnet-core.git against the parent's origin URL.
+        var subs = GitHelper.GetSubmodules(final);
+        Assert.Single(subs);
+        Assert.Equal("Core", subs[0].MountPath);
+        Assert.EndsWith("Org/infra-dotnet-core", subs[0].RepositoryName);
+    }
+
+    /// <summary>
+    /// Owns a temp directory and shells out to <c>git</c> to populate it. Disposal
+    /// removes the tree (best-effort: read-only objects under .git may resist deletion
+    /// on some filesystems).
+    /// </summary>
+    private sealed class GitWorkspace : IDisposable
+    {
+        public string Root { get; }
+        public string BareRoot { get; }
+        public string WorkRoot { get; }
+
+        public GitWorkspace()
+        {
+            Root = Path.Combine(Path.GetTempPath(), $"strazh-git-{Guid.NewGuid():N}");
+            BareRoot = Path.Combine(Root, "bare");
+            WorkRoot = Path.Combine(Root, "work");
+            Directory.CreateDirectory(BareRoot);
+            Directory.CreateDirectory(WorkRoot);
+        }
+
+        public string InitBare(string relativePath)
+        {
+            var path = Path.Combine(BareRoot, relativePath);
+            Directory.CreateDirectory(path);
+            RunGit(BareRoot, "init", "--bare", "--initial-branch=main", path);
+            return path;
+        }
+
+        public string Clone(string bareRepoPath, string workdirName)
+        {
+            var dest = Path.Combine(WorkRoot, workdirName);
+            RunGit(WorkRoot, "clone", FileUrl(bareRepoPath), dest);
+            RunGit(dest, "config", "user.email", "test@strazh.invalid");
+            RunGit(dest, "config", "user.name", "Strazh Test");
+            return dest;
+        }
+
+        public string CloneRecursive(string bareRepoPath, string workdirName)
+        {
+            var dest = Path.Combine(WorkRoot, workdirName);
+            RunGit(WorkRoot, "-c", "protocol.file.allow=always",
+                "clone", "--recursive", FileUrl(bareRepoPath), dest);
+            return dest;
+        }
+
+        public void Write(string repoDir, string relativePath, string content)
+        {
+            var p = Path.Combine(repoDir, relativePath);
+            Directory.CreateDirectory(Path.GetDirectoryName(p)!);
+            File.WriteAllText(p, content);
+        }
+
+        public void Git(string workingDir, params string[] args)
+            => RunGit(workingDir, args);
+
+        private static string FileUrl(string path)
+            => "file://" + path.Replace('\\', '/');
+
+        private static void RunGit(string workingDir, params string[] args)
+        {
+            var psi = new ProcessStartInfo("git")
+            {
+                WorkingDirectory = workingDir,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                UseShellExecute = false,
+            };
+            foreach (var a in args)
+            {
+                psi.ArgumentList.Add(a);
+            }
+            using var p = Process.Start(psi)
+                ?? throw new InvalidOperationException("Failed to start git");
+            var stdout = p.StandardOutput.ReadToEnd();
+            var stderr = p.StandardError.ReadToEnd();
+            p.WaitForExit();
+            if (p.ExitCode != 0)
+            {
+                throw new InvalidOperationException(
+                    $"git {string.Join(" ", args)} failed (exit={p.ExitCode})\nstderr: {stderr}\nstdout: {stdout}");
+            }
+        }
+
+        public void Dispose()
+        {
+            if (!Directory.Exists(Root))
+            {
+                return;
+            }
+            try
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+            catch
+            {
+                // Best-effort cleanup; .git objects can be read-only on some platforms.
+            }
+        }
+    }
+}

--- a/Strazh.Tests/GitHelperTests.cs
+++ b/Strazh.Tests/GitHelperTests.cs
@@ -1,0 +1,208 @@
+using System;
+using System.IO;
+using Strazh.Analysis;
+using Xunit;
+
+namespace Strazh.Tests;
+
+public class GitHelperTests
+{
+    [Fact]
+    public void FindGitRoot_RecognizesDotGitDirectory()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+
+        var found = GitHelper.FindGitRoot(tempRepo.Root);
+
+        Assert.Equal(tempRepo.Root, found);
+    }
+
+    /// <summary>
+    /// A checked-out git submodule stores its .git as a file (not a directory) whose
+    /// content points at the real git directory under the parent repo. FindGitRoot must
+    /// recognize that file so that paths inside the submodule resolve to the submodule's
+    /// root rather than walking up into the parent repo.
+    /// </summary>
+    [Fact]
+    public void FindGitRoot_RecognizesDotGitFile_InsideSubmoduleCheckout()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        var subRoot = tempRepo.AddSubmoduleCheckout("Core", "https://github.com/Org/child.git");
+
+        var found = GitHelper.FindGitRoot(subRoot);
+
+        Assert.Equal(subRoot, found);
+    }
+
+    [Fact]
+    public void GetRepositoryName_FromRegularRepo_ReturnsOriginOwnerSlashRepo()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+
+        Assert.Equal("Org/parent", GitHelper.GetRepositoryName(tempRepo.Root));
+    }
+
+    [Fact]
+    public void GetRepositoryName_FromScpStyleOrigin_ReturnsOwnerSlashRepo()
+    {
+        using var tempRepo = TempRepo.WithOrigin("git@github.com:Org/parent.git");
+
+        Assert.Equal("Org/parent", GitHelper.GetRepositoryName(tempRepo.Root));
+    }
+
+    [Fact]
+    public void GetRepositoryName_InsideSubmoduleCheckout_FollowsGitdirPointer()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        var subRoot = tempRepo.AddSubmoduleCheckout("Core", "https://github.com/Org/child.git");
+
+        Assert.Equal("Org/child", GitHelper.GetRepositoryName(subRoot));
+        // Parent still resolves correctly.
+        Assert.Equal("Org/parent", GitHelper.GetRepositoryName(tempRepo.Root));
+    }
+
+    [Fact]
+    public void GetSubmodules_NoGitmodulesFile_ReturnsEmpty()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+
+        Assert.Empty(GitHelper.GetSubmodules(tempRepo.Root));
+    }
+
+    [Fact]
+    public void GetSubmodules_RelativeUrl_ResolvedAgainstHttpsOrigin()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        tempRepo.WriteGitmodules("""
+            [submodule "Core"]
+                path = Core
+                url = ../child.git
+            """);
+
+        var subs = GitHelper.GetSubmodules(tempRepo.Root);
+
+        Assert.Single(subs);
+        Assert.Equal("Core", subs[0].MountPath);
+        Assert.Equal("Org/child", subs[0].RepositoryName);
+    }
+
+    [Fact]
+    public void GetSubmodules_RelativeUrl_ResolvedAgainstScpStyleOrigin()
+    {
+        using var tempRepo = TempRepo.WithOrigin("git@github.com:Org/parent.git");
+        tempRepo.WriteGitmodules("""
+            [submodule "Core"]
+                path = Core
+                url = ../child.git
+            """);
+
+        var subs = GitHelper.GetSubmodules(tempRepo.Root);
+
+        Assert.Single(subs);
+        Assert.Equal("Org/child", subs[0].RepositoryName);
+    }
+
+    [Fact]
+    public void GetSubmodules_DoubleDotRelativeUrl_CrossesOrgBoundary()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        tempRepo.WriteGitmodules("""
+            [submodule "X"]
+                path = X
+                url = ../../OtherOrg/foo.git
+            """);
+
+        var subs = GitHelper.GetSubmodules(tempRepo.Root);
+
+        Assert.Single(subs);
+        Assert.Equal("OtherOrg/foo", subs[0].RepositoryName);
+    }
+
+    [Fact]
+    public void GetSubmodules_AbsoluteHttpsUrl_ReturnedAsIs()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        tempRepo.WriteGitmodules("""
+            [submodule "X"]
+                path = X
+                url = https://github.com/Other/foo.git
+            """);
+
+        var subs = GitHelper.GetSubmodules(tempRepo.Root);
+
+        Assert.Equal("Other/foo", subs[0].RepositoryName);
+    }
+
+    [Fact]
+    public void GetSubmodules_AbsoluteScpUrl_ReturnedAsIs()
+    {
+        using var tempRepo = TempRepo.WithOrigin("https://github.com/Org/parent.git");
+        tempRepo.WriteGitmodules("""
+            [submodule "X"]
+                path = X
+                url = git@github.com:Other/foo.git
+            """);
+
+        var subs = GitHelper.GetSubmodules(tempRepo.Root);
+
+        Assert.Equal("Other/foo", subs[0].RepositoryName);
+    }
+
+    /// <summary>
+    /// Creates a temp directory containing a fake git repo with an <c>origin</c> remote,
+    /// suitable for exercising <see cref="GitHelper"/> without invoking git itself. Disposal
+    /// removes the directory tree.
+    /// </summary>
+    private sealed class TempRepo : IDisposable
+    {
+        public string Root { get; }
+
+        private TempRepo(string root)
+        {
+            Root = root;
+        }
+
+        public static TempRepo WithOrigin(string originUrl)
+        {
+            var root = Path.Combine(Path.GetTempPath(), $"strazh-githelper-{Guid.NewGuid():N}");
+            Directory.CreateDirectory(Path.Combine(root, ".git"));
+            File.WriteAllText(
+                Path.Combine(root, ".git", "config"),
+                $"[remote \"origin\"]\n\turl = {originUrl}\n");
+            return new TempRepo(root);
+        }
+
+        /// <summary>
+        /// Creates a fake submodule checkout at <paramref name="mountPath"/> with a
+        /// <c>.git</c> file pointing at <c>{parent}/.git/modules/{name}</c>, where the
+        /// submodule's own config holds its origin URL. Returns the submodule's root.
+        /// </summary>
+        public string AddSubmoduleCheckout(string mountPath, string submoduleOriginUrl)
+        {
+            var subGitDir = Path.Combine(Root, ".git", "modules", mountPath);
+            Directory.CreateDirectory(subGitDir);
+            File.WriteAllText(
+                Path.Combine(subGitDir, "config"),
+                $"[remote \"origin\"]\n\turl = {submoduleOriginUrl}\n");
+
+            var subRoot = Path.Combine(Root, mountPath);
+            Directory.CreateDirectory(subRoot);
+            // gitdir points from the submodule's root back into the parent's modules dir.
+            File.WriteAllText(
+                Path.Combine(subRoot, ".git"),
+                $"gitdir: ../.git/modules/{mountPath}");
+            return subRoot;
+        }
+
+        public void WriteGitmodules(string content)
+            => File.WriteAllText(Path.Combine(Root, ".gitmodules"), content);
+
+        public void Dispose()
+        {
+            if (Directory.Exists(Root))
+            {
+                Directory.Delete(Root, recursive: true);
+            }
+        }
+    }
+}

--- a/Strazh.Tests/GitModulesParserTests.cs
+++ b/Strazh.Tests/GitModulesParserTests.cs
@@ -1,0 +1,130 @@
+using Strazh.Analysis;
+using Xunit;
+
+namespace Strazh.Tests;
+
+public class GitModulesParserTests
+{
+    [Fact]
+    public void Parse_EmptyContent_ReturnsEmpty()
+    {
+        Assert.Empty(GitModulesParser.Parse(""));
+    }
+
+    [Fact]
+    public void Parse_SingleSubmodule_ReturnsOneEntryVerbatim()
+    {
+        var content = "[submodule \"Core\"]\n\tpath = Core\n\turl = ../infra-dotnet-core.git\n";
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Single(result);
+        Assert.Equal("Core", result[0].Name);
+        Assert.Equal("Core", result[0].Path);
+        Assert.Equal("../infra-dotnet-core.git", result[0].Url);
+    }
+
+    [Fact]
+    public void Parse_MultipleSubmodules_ReturnsAllEntriesInOrder()
+    {
+        var content = """
+            [submodule "Core"]
+                path = Core
+                url = ../infra-dotnet-core.git
+            [submodule "Vendor/Foo"]
+                path = vendor/foo
+                url = https://github.com/Org/foo.git
+            """;
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Equal(2, result.Count);
+        Assert.Equal("Core", result[0].Name);
+        Assert.Equal("Vendor/Foo", result[1].Name);
+        Assert.Equal("vendor/foo", result[1].Path);
+        Assert.Equal("https://github.com/Org/foo.git", result[1].Url);
+    }
+
+    [Fact]
+    public void Parse_IgnoresCommentsAndBlankLines()
+    {
+        var content = """
+            # leading comment
+            ; alternate comment style
+
+            [submodule "Core"]
+                # inside section
+                path = Core
+                url = ../core.git
+            """;
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Single(result);
+        Assert.Equal("Core", result[0].Path);
+    }
+
+    [Fact]
+    public void Parse_IgnoresOtherSectionsAndUnknownKeys()
+    {
+        var content = """
+            [core]
+                bare = false
+            [submodule "Core"]
+                path = Core
+                url = ../core.git
+                update = checkout
+                branch = main
+            """;
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Single(result);
+        Assert.Equal("Core", result[0].Path);
+        Assert.Equal("../core.git", result[0].Url);
+    }
+
+    [Fact]
+    public void Parse_TolerantOfKeyValueSpacing()
+    {
+        var content = """
+            [submodule "Core"]
+                path=Core
+                url   =   ../core.git
+            """;
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Single(result);
+        Assert.Equal("Core", result[0].Path);
+        Assert.Equal("../core.git", result[0].Url);
+    }
+
+    [Fact]
+    public void Parse_SubmoduleMissingPath_IsSkipped()
+    {
+        var content = """
+            [submodule "Core"]
+                url = ../core.git
+            [submodule "Good"]
+                path = good
+                url = ../good.git
+            """;
+
+        var result = GitModulesParser.Parse(content);
+
+        Assert.Single(result);
+        Assert.Equal("Good", result[0].Name);
+    }
+
+    [Fact]
+    public void Parse_SubmoduleMissingUrl_IsSkipped()
+    {
+        var content = """
+            [submodule "Core"]
+                path = Core
+            """;
+
+        Assert.Empty(GitModulesParser.Parse(content));
+    }
+}

--- a/Strazh.Tests/InMemoryTripleStore.cs
+++ b/Strazh.Tests/InMemoryTripleStore.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Database;
+using Strazh.Domain;
+
+namespace Strazh.Tests;
+
+/// <summary>
+/// Test double for <see cref="ITripleStore"/> that collects triples in memory
+/// so tests can assert on what the analysis pipeline produced without requiring
+/// a live Neo4j connection.
+/// </summary>
+public class InMemoryTripleStore : ITripleStore
+{
+    private readonly List<Triple> _triples = [];
+    private readonly object _lock = new();
+
+    public IReadOnlyList<Triple> Triples
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _triples.ToArray();
+            }
+        }
+    }
+
+    public Task EnsureIndexesAsync() => Task.CompletedTask;
+
+    public Task DeleteAllAsync()
+    {
+        lock (_lock)
+        {
+            _triples.Clear();
+        }
+        return Task.CompletedTask;
+    }
+
+    public Task InsertAsync(IList<Triple> triples)
+    {
+        lock (_lock)
+        {
+            _triples.AddRange(triples);
+        }
+        return Task.CompletedTask;
+    }
+}

--- a/Strazh.Tests/NullAnalysisProgress.cs
+++ b/Strazh.Tests/NullAnalysisProgress.cs
@@ -16,7 +16,7 @@ public class NullAnalysisProgress : IAnalysisProgress
 
     public Task WrapAsync(int totalProjects, Func<Task> action) => action();
 
-    public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit) { }
+    public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building") { }
     public void OnBuildCompleted(string projectFilePath) { }
     public void OnStageChanged(string projectFilePath, string projectName, string stage) { }
     public void OnProjectCompleted(string projectFilePath, int tripleCount) { }

--- a/Strazh.Tests/NullAnalysisProgress.cs
+++ b/Strazh.Tests/NullAnalysisProgress.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Analysis;
+using Strazh.Domain;
+
+namespace Strazh.Tests;
+
+/// <summary>
+/// No-op implementation of <see cref="IAnalysisProgress"/> for tests that drive
+/// the full analysis pipeline but don't need progress reporting.
+/// </summary>
+public class NullAnalysisProgress : IAnalysisProgress
+{
+    public static readonly NullAnalysisProgress Instance = new();
+
+    public Task WrapAsync(int totalProjects, Func<Task> action) => action();
+
+    public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit) { }
+    public void OnBuildCompleted(string projectFilePath) { }
+    public void OnStageChanged(string projectFilePath, string projectName, string stage) { }
+    public void OnProjectCompleted(string projectFilePath, int tripleCount) { }
+    public void OnProjectSkipped(string projectFilePath, string filename, string reason) { }
+    public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples) { }
+}

--- a/Strazh.Tests/NullAnalysisProgress.cs
+++ b/Strazh.Tests/NullAnalysisProgress.cs
@@ -16,7 +16,7 @@ public class NullAnalysisProgress : IAnalysisProgress
 
     public Task WrapAsync(int totalProjects, Func<Task> action) => action();
 
-    public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building") { }
+    public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel) { }
     public void OnBuildCompleted(string projectFilePath) { }
     public void OnStageChanged(string projectFilePath, string projectName, string stage) { }
     public void OnProjectCompleted(string projectFilePath, int tripleCount) { }

--- a/Strazh.Tests/Strazh.Tests.csproj
+++ b/Strazh.Tests/Strazh.Tests.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/Strazh.Tests/Strazh.Tests.csproj
+++ b/Strazh.Tests/Strazh.Tests.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Strazh\Strazh.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -163,7 +163,7 @@ namespace Strazh.Analysis
         // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private readonly struct StreamCallbacks
         {
-            public Action<string, string, bool, string>? OnBuildStarted { get; init; }
+            public Action<string, string, bool, BuildStageLabel>? OnBuildStarted { get; init; }
             public Action<string>? OnBuildCompleted { get; init; }
             public Action<string, string, string>? OnProjectSkipped { get; init; }
         }
@@ -178,12 +178,12 @@ namespace Strazh.Analysis
             string Directory,
             HashSet<string> ProjectsNeedingRebuild);
 
-        // Carries the full context for one build stage (Scanning or Building).
+        // Carries the full context for one build stage (Building or Graphing).
         private readonly record struct BuildStageContext(
             IAnalyzerManager Manager,
             CacheContext? Cache,
             StreamCallbacks Callbacks,
-            string BuildLabel,
+            BuildStageLabel BuildLabel,
             bool IsScanPass,
             string? BuildLogDirectory);
 
@@ -214,34 +214,35 @@ namespace Strazh.Analysis
                     : ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
             }
 
-            // Scan pass: if any project is missing a .deps sidecar the dependency graph is
+            // Building pass: if any project is missing a .deps sidecar the dependency graph is
             // incomplete, so we cannot reliably detect transitive staleness or know which
             // projects are safe to build in parallel without their dependencies present.
-            // Build everything in parallel first (Scanning) to populate binlog cache and
+            // Run full MSBuild invocations for all projects to populate the binlog cache and
             // .deps files, then re-derive the rebuild set from the now-complete graph before
-            // the main build pass. On warm-cache runs all .deps files exist and this is skipped.
+            // the Graphing pass. On warm-cache runs all .deps files exist and this is skipped.
             if (options.CacheDirectory != null && manager.Projects.Values.Any(
                     p => !File.Exists(GetBinlogCachePath(options.CacheDirectory, p) + ".deps")))
             {
                 await RunBuildStageAsync(new BuildStageContext(
                     manager, new CacheContext(options.CacheDirectory, projectsNeedingRebuild!),
-                    options.Callbacks, BuildLabel: "Building", IsScanPass: true, options.BuildLogDirectory));
-                // Re-derive the rebuild set without the noCache override — the scan pass
+                    options.Callbacks, BuildLabel: BuildStageLabel.Building, IsScanPass: true, options.BuildLogDirectory));
+                // Re-derive the rebuild set without the noCache override — the Building pass
                 // just built everything fresh, so nothing should be considered stale.
                 projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
             }
 
-            // Main build pass: run MSBuild design-time builds in parallel, capped at the
-            // number of logical processors. Each project may target multiple frameworks;
-            // the build task returns all TFM results so each one can be analyzed independently.
+            // Graphing pass: replays the binlog cache for each project (or runs a fresh MSBuild
+            // build if the cache is stale), then loads the results into the Roslyn workspace for
+            // triple extraction, grouping, and insertion into the graph database. Each project may
+            // target multiple frameworks; results from all TFMs are analyzed independently.
             // A project is considered successful if at least one TFM produces a result.
-            // After a scan pass this is mostly cache replays (fast); on warm-cache runs it
+            // After a Building pass this is mostly cache replays (fast); on warm-cache runs it
             // rebuilds only the stale subset.
             CacheContext? mainCache = options.CacheDirectory != null
                 ? new CacheContext(options.CacheDirectory, projectsNeedingRebuild!)
                 : null;
             IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(new BuildStageContext(
-                manager, mainCache, options.Callbacks, BuildLabel: "Scanning", IsScanPass: false, options.BuildLogDirectory));
+                manager, mainCache, options.Callbacks, BuildLabel: BuildStageLabel.Graphing, IsScanPass: false, options.BuildLogDirectory));
 
             // Load stage: add each completed result to the workspace and yield immediately,
             // so analysis can begin on each project without waiting for all to be loaded.
@@ -360,7 +361,7 @@ namespace Strazh.Analysis
         // one result slot per project (null for skipped/failed projects).
         //
         // buildLabel is forwarded to OnBuildStarted so the progress UI can distinguish
-        // "Building" (dependency-discovery pass) from "Scanning" (main pass).
+        // Building (dependency-discovery pass) from Graphing (knowledge-graph pass).
         //
         // isScanPass suppresses OnProjectSkipped for failures: scan failures are pre-work
         // noise that will be reported properly by the main pass. OnBuildCompleted is called

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -347,116 +347,160 @@ namespace Strazh.Analysis
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        var projectPath = p.ProjectFile.Path;
-                        var projectName = GetProjectName(p.ProjectFile.Name);
-                        var projectFileName = Path.GetFileName(projectPath);
-
-                        if (cacheDirectory != null)
-                        {
-                            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-
-                            // Cache-hit: replay the existing binlog; fall through to fresh build on failure.
-                            if (!projectsNeedingRebuild!.Contains(projectPath) && File.Exists(binlogPath))
-                            {
-                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
-                                var cached = RealTfmResults(manager.Analyze(binlogPath));
-                                if (cached.Any(r => r.Succeeded))
-                                {
-                                    // Project references are patched from the Roslyn workspace in the
-                                    // Load stage, which also overwrites the deps sidecar. Nothing to
-                                    // do here beyond signalling completion.
-                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                    return cached;
-                                }
-                                // Stale or corrupted cached binlog — fall through to a fresh build.
-                            }
-
-                            // Fresh-build retry loop (max MaxBuildAttempts attempts).
-                            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
-                            {
-                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
-                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath, binlogPath));
-                                if (timedOut)
-                                {
-                                    if (isScanPass)
-                                        callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                    else
-                                        callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build timed out");
-                                    return null;
-                                }
-                                // Read from the binlog rather than the pipe result. The pipe uses
-                                // MsBuildPipeLogger, which may not support the event types emitted by
-                                // the SDK's MSBuild version, leaving the pipe result empty even on a
-                                // successful build. The binlog is written natively by MSBuild and read
-                                // by StructuredLogger, which handles the current format regardless of
-                                // version skew.
-                                var binlogExists = File.Exists(binlogPath);
-                                var tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
-                                if (tfmResults.Any(r => r.Succeeded))
-                                {
-                                    // Write an initial deps sidecar with whatever project references
-                                    // MSBuild returned. Binlog replay often leaves this empty (MSBuild
-                                    // 17.14+ does not emit ProjectReferences into the replay). The Load
-                                    // stage patches from the Roslyn workspace and overwrites the file
-                                    // with the correct paths so subsequent staleness checks are accurate.
-                                    WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
-                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                    return tfmResults;
-                                }
-                                if (attempt < MaxBuildAttempts)
-                                {
-                                    if (binlogExists)
-                                    {
-                                        File.Delete(binlogPath);
-                                    }
-                                    continue;
-                                }
-                                var reason = binlogExists ? "build log could not be read" : "build failed";
-                                if (isScanPass)
-                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                else
-                                    callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, reason);
-                                return null;
-                            }
-                        }
-                        else
-                        {
-                            // No cache — retry loop against pipe results.
-                            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
-                            {
-                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
-                                var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath));
-                                if (timedOut2)
-                                {
-                                    if (isScanPass)
-                                        callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                    else
-                                        callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build timed out");
-                                    return null;
-                                }
-                                if (buildResults2 != null && buildResults2.Any(r => r.Succeeded))
-                                {
-                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                    return buildResults2;
-                                }
-                                if (attempt < MaxBuildAttempts)
-                                {
-                                    continue;
-                                }
-                                if (isScanPass)
-                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                                else
-                                    callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build failed");
-                                return null;
-                            }
-                        }
-                        return null; // unreachable — loops always return
+                        return await BuildSingleProjectAsync(p, manager, cacheDirectory,
+                            projectsNeedingRebuild, callbacks, buildLabel, isScanPass, buildLogDirectory);
                     }
                     finally
                     {
                         buildSemaphore.Release();
                     }
                 })));
+        }
+
+        private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildSingleProjectAsync(
+            IProjectAnalyzer p,
+            IAnalyzerManager manager,
+            string? cacheDirectory,
+            HashSet<string>? projectsNeedingRebuild,
+            StreamCallbacks callbacks,
+            string buildLabel,
+            bool isScanPass,
+            string? buildLogDirectory)
+        {
+            var projectPath = p.ProjectFile.Path;
+            var projectName = GetProjectName(p.ProjectFile.Name);
+            var projectFileName = Path.GetFileName(projectPath);
+            if (cacheDirectory != null)
+            {
+                return await BuildProjectWithCacheAsync(p, manager, cacheDirectory,
+                    projectsNeedingRebuild!, projectPath, projectName, projectFileName,
+                    callbacks, buildLabel, isScanPass, buildLogDirectory);
+            }
+            return await BuildProjectWithoutCacheAsync(p, projectPath, projectName, projectFileName,
+                callbacks, buildLabel, isScanPass, buildLogDirectory);
+        }
+
+        private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildProjectWithCacheAsync(
+            IProjectAnalyzer p,
+            IAnalyzerManager manager,
+            string cacheDirectory,
+            HashSet<string> projectsNeedingRebuild,
+            string projectPath,
+            string projectName,
+            string projectFileName,
+            StreamCallbacks callbacks,
+            string buildLabel,
+            bool isScanPass,
+            string? buildLogDirectory)
+        {
+            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
+
+            // Cache-hit: replay the existing binlog; fall through to fresh build on failure.
+            if (!projectsNeedingRebuild.Contains(projectPath) && File.Exists(binlogPath))
+            {
+                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
+                var cached = RealTfmResults(manager.Analyze(binlogPath));
+                if (cached.Any(r => r.Succeeded))
+                {
+                    // Project references are patched from the Roslyn workspace in the
+                    // Load stage, which also overwrites the deps sidecar. Nothing to
+                    // do here beyond signalling completion.
+                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                    return cached;
+                }
+                // Stale or corrupted cached binlog — fall through to a fresh build.
+            }
+
+            // Fresh-build retry loop (max MaxBuildAttempts attempts).
+            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
+            {
+                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
+                var outcome = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath, binlogPath));
+                if (outcome.TimedOut)
+                {
+                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build timed out");
+                    return null;
+                }
+                // Read from the binlog rather than the pipe result. The pipe uses
+                // MsBuildPipeLogger, which may not support the event types emitted by
+                // the SDK's MSBuild version, leaving the pipe result empty even on a
+                // successful build. The binlog is written natively by MSBuild and read
+                // by StructuredLogger, which handles the current format regardless of
+                // version skew.
+                var binlogExists = File.Exists(binlogPath);
+                var tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
+                if (tfmResults.Any(r => r.Succeeded))
+                {
+                    // Write an initial deps sidecar with whatever project references
+                    // MSBuild returned. Binlog replay often leaves this empty (MSBuild
+                    // 17.14+ does not emit ProjectReferences into the replay). The Load
+                    // stage patches from the Roslyn workspace and overwrites the file
+                    // with the correct paths so subsequent staleness checks are accurate.
+                    WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
+                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                    return tfmResults;
+                }
+                else if (attempt < MaxBuildAttempts)
+                {
+                    if (binlogExists)
+                    {
+                        File.Delete(binlogPath);
+                    }
+                }
+                else
+                {
+                    var reason = binlogExists ? "build log could not be read" : "build failed";
+                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, reason);
+                    return null;
+                }
+            }
+            return null; // unreachable — loop always returns
+        }
+
+        private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildProjectWithoutCacheAsync(
+            IProjectAnalyzer p,
+            string projectPath,
+            string projectName,
+            string projectFileName,
+            StreamCallbacks callbacks,
+            string buildLabel,
+            bool isScanPass,
+            string? buildLogDirectory)
+        {
+            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
+            {
+                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
+                var outcome = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath));
+                if (outcome.TimedOut)
+                {
+                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build timed out");
+                    return null;
+                }
+                if (outcome.Results != null && outcome.Results.Any(r => r.Succeeded))
+                {
+                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                    return outcome.Results;
+                }
+                if (attempt == MaxBuildAttempts)
+                {
+                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build failed");
+                    return null;
+                }
+            }
+            return null; // unreachable — loop always returns
+        }
+
+        private static void SignalBuildNotCompleted(
+            StreamCallbacks callbacks, bool isScanPass, string projectPath, string projectFileName, string reason)
+        {
+            if (isScanPass)
+            {
+                callbacks.OnBuildCompleted?.Invoke(projectPath);
+            }
+            else
+            {
+                callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, reason);
+            }
         }
 
         // If a build hangs (e.g. Android/MAUI projects waiting on SDK tools not present in the
@@ -482,7 +526,9 @@ namespace Strazh.Analysis
             return RealTfmResults(manager.Analyze(binlogPath));
         }
 
-        private static async Task<(IReadOnlyList<IAnalyzerResult>? results, bool timedOut)> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
+        private readonly record struct BuildOutcome(IReadOnlyList<IAnalyzerResult>? Results, bool TimedOut);
+
+        private static async Task<BuildOutcome> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
         {
             var buildTask = Task.Run<IReadOnlyList<IAnalyzerResult>?>(() =>
             {
@@ -491,9 +537,9 @@ namespace Strazh.Analysis
             });
             if (await Task.WhenAny(buildTask, Task.Delay(BuildTimeout)).ConfigureAwait(false) != buildTask)
             {
-                return (null, timedOut: true);
+                return new BuildOutcome(null, TimedOut: true);
             }
-            return (await buildTask.ConfigureAwait(false), timedOut: false);
+            return new BuildOutcome(await buildTask.ConfigureAwait(false), TimedOut: false);
         }
 
         // Filters out entries that don't correspond to a real target-framework build.
@@ -758,13 +804,17 @@ namespace Strazh.Analysis
             IReadOnlyList<IAnalyzerResult> tfmGroup, Project roslynProject, AdhocWorkspace workspace)
         {
             if (tfmGroup.Any(r => r.ProjectReferences.Any()))
+            {
                 return tfmGroup;
+            }
             var refPaths = roslynProject.ProjectReferences
                 .Select(pr => workspace.CurrentSolution.GetProject(pr.ProjectId)?.FilePath)
                 .OfType<string>()
                 .ToList();
             if (refPaths.Count == 0)
+            {
                 return tfmGroup;
+            }
             return tfmGroup
                 .Select(r => (IAnalyzerResult)new AnalyzerResultWithProjectRefs(r, refPaths))
                 .ToList();

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -8,11 +8,9 @@ using Buildalyzer;
 using Buildalyzer.Workspaces;
 using System.Collections.Generic;
 using System;
-using System.Collections.Concurrent;
 using Strazh.Database;
 using static Strazh.Analysis.AnalyzerConfig;
 using System.IO;
-using Microsoft.Build.Construction;
 
 namespace Strazh.Analysis
 {
@@ -31,12 +29,6 @@ namespace Strazh.Analysis
                 : config.Projects.Select(x => manager.GetProject(x))).ToList();
 
             Console.WriteLine($"Analyzer ready to analyze {projectAnalyzers.Count} project/s.");
-            
-            Console.WriteLine("Building workspace...");
-            var context = GetAnalysisContext(manager);
-            Console.WriteLine("done.");
-            
-            Console.WriteLine("Analyzing workspace...");
 
             // Delete graph data upfront before parallel analysis begins, so that no project
             // races against the delete.
@@ -45,80 +37,91 @@ namespace Strazh.Analysis
                 await DbManager.DeleteData(config.Credentials);
             }
 
+            var workspace = CreateWorkspace(manager);
+
             // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
             var semaphore = new SemaphoreSlim(4);
-            var total = context.Projects.Count;
+            var total = projectAnalyzers.Count;
+            var tasks = new List<Task>();
+            var index = 0;
 
-            // Analyze and insert all projects concurrently. Task.Run ensures CPU-bound work
-            // (syntax tree walking) runs on thread-pool threads rather than the calling thread.
-            var tasks = context.Projects.Select((entry, index) => Task.Run(async () =>
+            // Stream projects through the Build → Load pipeline and launch an Analyze + Insert
+            // task for each one as soon as it becomes available, without waiting for all
+            // projects to finish building and loading first.
+            await foreach (var entry in StreamProjectsAsync(manager, workspace))
             {
-                var triples = new List<Triple>();
+                var capturedEntry = entry;
+                var capturedIndex = index++;
 
-                if (config.IsSolutionBased)
+                tasks.Add(Task.Run(async () =>
                 {
-                    var solutionRoot = GetRoot(manager.SolutionFilePath);
-                    var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+                    var triples = new List<Triple>();
 
-                    var solutionName = GetSolutionName(manager.SolutionFilePath);
-                    var solutionNode = new SolutionNode(solutionName);
-                    triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-
-                    var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
-                    triples.Add(new TripleContains(solutionNode, projectNode));
-                }
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - starting");
-                var projectTriples = await AnalyzeProject(index + 1, entry, config.Tier);
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - finished");
-
-                triples.AddRange(projectTriples);
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - starting");
-                try
-                {
-                    triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
-                        .ToList();
-                }
-                catch (Exception)
-                {
-                    Console.WriteLine("Error detected. Dumping detailed logging data.");
-                    Console.WriteLine("[");
-                    var first = true;
-                    foreach (var triple in triples)
+                    if (config.IsSolutionBased)
                     {
-                        if (!first)
+                        var solutionRoot = GetRoot(manager.SolutionFilePath);
+                        var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+
+                        var solutionName = GetSolutionName(manager.SolutionFilePath);
+                        var solutionNode = new SolutionNode(solutionName);
+                        triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
+
+                        var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
+                        triples.Add(new TripleContains(solutionNode, projectNode));
+                    }
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - starting");
+                    var projectTriples = await AnalyzeProject(capturedIndex + 1, capturedEntry, config.Tier);
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - finished");
+
+                    triples.AddRange(projectTriples);
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - starting");
+                    try
+                    {
+                        triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
+                            .ToList();
+                    }
+                    catch (Exception)
+                    {
+                        Console.WriteLine("Error detected. Dumping detailed logging data.");
+                        Console.WriteLine("[");
+                        var first = true;
+                        foreach (var triple in triples)
                         {
-                            Console.WriteLine(",");
+                            if (!first)
+                            {
+                                Console.WriteLine(",");
+                            }
+                            Console.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
+
+                            first = false;
                         }
-                        Console.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
-
-                        first = false;
+                        if (triples.Any())
+                        {
+                            Console.WriteLine("");
+                        }
+                        Console.WriteLine("]");
+                        throw;
                     }
-                    if (triples.Any())
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - finished");
+
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - starting");
+                    await semaphore.WaitAsync();
+                    try
                     {
-                        Console.WriteLine("");
+                        await DbManager.InsertData(triples, config.Credentials);
                     }
-                    Console.WriteLine("]");
-                    throw;
-                }
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - finished");
-
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - starting");
-                await semaphore.WaitAsync();
-                try
-                {
-                    await DbManager.InsertData(triples, config.Credentials);
-                }
-                finally
-                {
-                    semaphore.Release();
-                }
-                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - finished");
-            })).ToList();
+                    finally
+                    {
+                        semaphore.Release();
+                    }
+                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - finished");
+                }));
+            }
 
             await Task.WhenAll(tasks);
-            context.Workspace.Dispose();
+            workspace.Dispose();
         }
 
         public class AnalysisContext(AdhocWorkspace workspace, List<(Project, IAnalyzerResult)> projects)
@@ -128,71 +131,82 @@ namespace Strazh.Analysis
         }
         
         // Based on https://github.com/phmonte/Buildalyzer/blob/9db3390b49dca033fd3f70439bab3a6327440a47/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs#L24-L60
-        public static AnalysisContext GetAnalysisContext(IAnalyzerManager manager)
+        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager)
         {
             if (manager is null)
             {
                 throw new ArgumentNullException(nameof(manager));
             }
-            
-            var projectResults = new ConcurrentBag<(Project, IAnalyzerResult)>(); 
 
-            Console.WriteLine("Building projects - starting");
-            
-            // Build projects in parallel — each invocation spawns an isolated MSBuild process
-            // so there is no shared mutable state between concurrent builds.
-            List<IAnalyzerResult?> results = manager.Projects.Values
-                .AsParallel()
-                .Select(p =>
-                {
-                    Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
-                    var result = p.Build().FirstOrDefault();
-                    Console.WriteLine($"Building projects - {p.ProjectFile.Name} - finished");
-                    return result;
-                })
-                .Where(x => x != null)
-                .ToList();
-            Console.WriteLine("Building projects - finished.");
-
-            // Create a new workspace and add the solution (if there was one)
-            AdhocWorkspace workspace = new AdhocWorkspace();
-            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+            var workspace = CreateWorkspace(manager);
+            var projects = new List<(Project, IAnalyzerResult)>();
+            await foreach (var item in StreamProjectsAsync(manager, workspace))
             {
-                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
-                workspace.AddSolution(solutionInfo);
-
-                // Sort the projects so the order that they're added to the workspace in the same order as the solution file
-                List<ProjectInSolution> projectsInOrder = [.. manager.SolutionFile.ProjectsInOrder];
-                results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
+                projects.Add(item);
             }
 
-            // Add each result to the new workspace (sorted in solution order above, if we have a solution).
-            // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
-            Console.WriteLine("Loading projects into workspace - starting");
-            foreach (IAnalyzerResult result in results)
+            return new AnalysisContext(workspace, projects);
+        }
+
+        // Launches all MSBuild design-time builds in parallel (Build stage), then as each
+        // completes feeds it sequentially into the Roslyn AdhocWorkspace (Load stage), and
+        // yields the (Project, IAnalyzerResult) pair immediately — without waiting for all
+        // projects to finish first.
+        //
+        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential while
+        // the underlying builds run concurrently on the thread pool.
+        private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
+            IAnalyzerManager manager, AdhocWorkspace workspace)
+        {
+            // Build stage: launch all MSBuild design-time builds concurrently
+            List<Task<IAnalyzerResult?>> buildTasks = manager.Projects.Values
+                .Select(p => Task.Run<IAnalyzerResult?>(() =>
+                {
+                    Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                    var result = p.Build().FirstOrDefault();
+                    Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                    return result;
+                }))
+                .ToList();
+
+            // Load stage: as each build completes, add it to the workspace immediately
+            await foreach (var completedTask in Task.WhenEach(buildTasks))
             {
-                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - starting");
-                var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
+                var result = await completedTask;
+                if (result is null) continue;
+
+                Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");
+                var existingProject = workspace.CurrentSolution.Projects
+                    .FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
                 if (existingProject is null)
                 {
                     // AddToWorkspace with addProjectReferences: true eagerly adds referenced projects
                     // into the workspace. Those will be picked up via existingProject on their own
-                    // loop iteration below.
+                    // iteration below.
                     var project = result.AddToWorkspace(workspace, true);
-                    projectResults.Add((project, result));
+                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
+                    yield return (project, result);
                 }
                 else
                 {
                     // Already in the workspace because an earlier project pulled it in as a
                     // transitive reference. Still include it so it gets CONTAINS triples and
                     // is analyzed — just reuse the workspace Project object already there.
-                    projectResults.Add((existingProject, result));
+                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
+                    yield return (existingProject, result);
                 }
-                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - finished");
             }
-            Console.WriteLine("Loading projects into workspace - finished");
+        }
 
-            return new AnalysisContext(workspace, projectResults.ToList());
+        private static AdhocWorkspace CreateWorkspace(IAnalyzerManager manager)
+        {
+            var workspace = new AdhocWorkspace();
+            if (!string.IsNullOrEmpty(manager.SolutionFilePath))
+            {
+                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+                workspace.AddSolution(solutionInfo);
+            }
+            return workspace;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject(int index, (Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -11,6 +11,8 @@ using System;
 using Strazh.Database;
 using static Strazh.Analysis.AnalyzerConfig;
 using System.IO;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Strazh.Analysis
 {
@@ -48,7 +50,7 @@ namespace Strazh.Analysis
             // Stream projects through the Build → Load pipeline and launch an Analyze + Insert
             // task for each one as soon as it becomes available, without waiting for all
             // projects to finish building and loading first.
-            await foreach (var entry in StreamProjectsAsync(manager, workspace))
+            await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory))
             {
                 var capturedEntry = entry;
                 var capturedIndex = index++;
@@ -131,7 +133,7 @@ namespace Strazh.Analysis
         }
         
         // Based on https://github.com/phmonte/Buildalyzer/blob/9db3390b49dca033fd3f70439bab3a6327440a47/src/Buildalyzer.Workspaces/AnalyzerManagerExtensions.cs#L24-L60
-        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager)
+        public static async Task<AnalysisContext> GetAnalysisContext(IAnalyzerManager manager, string? cacheDirectory = null)
         {
             if (manager is null)
             {
@@ -140,7 +142,7 @@ namespace Strazh.Analysis
 
             var workspace = CreateWorkspace(manager);
             var projects = new List<(Project, IAnalyzerResult)>();
-            await foreach (var item in StreamProjectsAsync(manager, workspace))
+            await foreach (var item in StreamProjectsAsync(manager, workspace, cacheDirectory))
             {
                 projects.Add(item);
             }
@@ -161,8 +163,15 @@ namespace Strazh.Analysis
         //
         // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
-            IAnalyzerManager manager, AdhocWorkspace workspace)
+            IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null)
         {
+            HashSet<string>? projectsNeedingRebuild = null;
+            if (cacheDirectory != null)
+            {
+                Directory.CreateDirectory(cacheDirectory);
+                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+            }
+
             // Build stage: run MSBuild design-time builds in parallel, capped at the number
             // of logical processors so we don't spawn an unbounded number of dotnet processes
             var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
@@ -172,9 +181,33 @@ namespace Strazh.Analysis
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
-                        var result = p.Build().FirstOrDefault();
-                        Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        IAnalyzerResult? result;
+                        if (cacheDirectory != null)
+                        {
+                            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
+                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
+                            {
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                                p.AddBinaryLogger(binlogPath);
+                                result = p.Build().FirstOrDefault();
+                                if (result != null)
+                                {
+                                    WriteDepsFile(binlogPath, result);
+                                }
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                            }
+                            else
+                            {
+                                Console.WriteLine($"Build - {p.ProjectFile.Name} - cache hit");
+                                result = manager.Analyze(binlogPath).FirstOrDefault();
+                            }
+                        }
+                        else
+                        {
+                            Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                            result = p.Build().FirstOrDefault();
+                            Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        }
                         return result;
                     }
                     finally
@@ -187,7 +220,10 @@ namespace Strazh.Analysis
             // so analysis can begin on each project without waiting for all to be loaded
             foreach (var result in results)
             {
-                if (result is null) continue;
+                if (result is null)
+                {
+                    continue;
+                }
 
                 Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");
                 var existingProject = workspace.CurrentSolution.Projects
@@ -221,6 +257,108 @@ namespace Strazh.Analysis
                 workspace.AddSolution(solutionInfo);
             }
             return workspace;
+        }
+
+        private static string GetBinlogCachePath(string cacheDirectory, IProjectAnalyzer p)
+        {
+            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(p.ProjectFile.Path));
+            var hash = Convert.ToHexString(bytes)[..8];
+            return Path.Combine(cacheDirectory, $"{p.ProjectFile.Name}_{hash}.binlog");
+        }
+
+        // Returns true if no binlog exists, or if the binlog is older than any source or
+        // build file in the project directory (excluding obj/ and bin/ output folders).
+        private static bool IsBinlogStale(string binlogPath, string projectFilePath)
+        {
+            if (!File.Exists(binlogPath))
+            {
+                return true;
+            }
+
+            var binlogTime = File.GetLastWriteTimeUtc(binlogPath);
+
+            if (File.GetLastWriteTimeUtc(projectFilePath) > binlogTime)
+            {
+                return true;
+            }
+
+            var projectDir = Path.GetDirectoryName(projectFilePath)!;
+            var trackedExtensions = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                { ".cs", ".fs", ".vb", ".props", ".targets" };
+
+            foreach (var file in Directory.EnumerateFiles(projectDir, "*", SearchOption.AllDirectories))
+            {
+                if (file.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}") ||
+                    file.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}"))
+                {
+                    continue;
+                }
+
+                if (trackedExtensions.Contains(Path.GetExtension(file)) &&
+                    File.GetLastWriteTimeUtc(file) > binlogTime)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        // Writes the fully-evaluated project references from a build result as a sidecar next to
+        // the binlog. Subsequent runs read this instead of parsing the project file, so all
+        // MSBuild evaluation (conditions, imports, Directory.Build.props, etc.) is accounted for.
+        private static void WriteDepsFile(string binlogPath, IAnalyzerResult result) =>
+            File.WriteAllLines(binlogPath + ".deps", result.ProjectReferences);
+
+        // Reads the deps sidecar written by a previous build. Returns empty when the file does
+        // not exist (first run, or cache cleared) — the project will be stale for other reasons.
+        private static IReadOnlyList<string> ReadDepsFile(string binlogPath)
+        {
+            var depsPath = binlogPath + ".deps";
+            return File.Exists(depsPath) ? File.ReadAllLines(depsPath) : [];
+        }
+
+        // Determines which projects must be rebuilt, accounting for transitive dependencies:
+        // if project B needs a rebuild and project A references B, A is also marked for rebuild.
+        // The dependency graph is reconstructed from the sidecar files written by previous builds,
+        // so MSBuild's own evaluation (conditions, imports, etc.) is used — not our own parsing.
+        private static HashSet<string> ComputeProjectsNeedingRebuild(
+            IEnumerable<IProjectAnalyzer> projects, string cacheDirectory)
+        {
+            var projectMap = projects.ToDictionary(p => p.ProjectFile.Path, StringComparer.OrdinalIgnoreCase);
+
+            var depGraph = projectMap.ToDictionary(
+                kvp => kvp.Key,
+                kvp => ReadDepsFile(GetBinlogCachePath(cacheDirectory, kvp.Value))
+                    .Where(r => projectMap.ContainsKey(r))
+                    .ToList(),
+                StringComparer.OrdinalIgnoreCase);
+
+            var needsRebuild = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            foreach (var (path, analyzer) in projectMap)
+            {
+                if (IsBinlogStale(GetBinlogCachePath(cacheDirectory, analyzer), path))
+                {
+                    needsRebuild.Add(path);
+                }
+            }
+
+            // Propagate: if a referenced project needs a rebuild, so does the referencing project
+            bool changed;
+            do
+            {
+                changed = false;
+                foreach (var (path, refs) in depGraph)
+                {
+                    if (!needsRebuild.Contains(path) && refs.Any(r => needsRebuild.Contains(r)))
+                    {
+                        needsRebuild.Add(path);
+                        changed = true;
+                    }
+                }
+            } while (changed);
+
+            return needsRebuild;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject(int index, (Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -39,8 +39,8 @@ namespace Strazh.Analysis
 
             var workspace = CreateWorkspace(manager);
 
-            // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
-            var semaphore = new SemaphoreSlim(4);
+            // Limit concurrent Neo4j connections to one per logical processor.
+            var semaphore = new SemaphoreSlim(Environment.ProcessorCount);
             var total = projectAnalyzers.Count;
             var tasks = new List<Task>();
             var index = 0;

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -39,6 +39,11 @@ namespace Strazh.Analysis
                 await DbManager.DeleteData(config.Credentials);
             }
 
+            // Ensure uniqueness constraints (and their implicit indexes) exist for every node
+            // label before any MERGE operations run. Without indexes, each MERGE does a full
+            // label scan and performance degrades linearly as the database grows.
+            await DbManager.EnsureIndexes(config.Credentials);
+
             var workspace = CreateWorkspace(manager);
 
             // Limit concurrent Neo4j connections to one per logical processor.

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -394,24 +394,58 @@ namespace Strazh.Analysis
             string? buildLogDirectory)
         {
             var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-
-            // Cache-hit: replay the existing binlog; fall through to fresh build on failure.
-            if (!projectsNeedingRebuild.Contains(projectPath) && File.Exists(binlogPath))
+            var cached = TryReplayCachedBinlog(manager, projectsNeedingRebuild, projectPath, projectName,
+                binlogPath, callbacks, buildLabel);
+            if (cached != null)
             {
-                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
-                var cached = RealTfmResults(manager.Analyze(binlogPath));
-                if (cached.Any(r => r.Succeeded))
-                {
-                    // Project references are patched from the Roslyn workspace in the
-                    // Load stage, which also overwrites the deps sidecar. Nothing to
-                    // do here beyond signalling completion.
-                    callbacks.OnBuildCompleted?.Invoke(projectPath);
-                    return cached;
-                }
-                // Stale or corrupted cached binlog — fall through to a fresh build.
+                return cached;
             }
+            return await RunFreshBuildLoopAsync(p, manager, binlogPath, projectPath, projectName, projectFileName,
+                callbacks, buildLabel, isScanPass, buildLogDirectory);
+        }
 
-            // Fresh-build retry loop (max MaxBuildAttempts attempts).
+        // Attempts to replay a cached binlog. Returns the results on success, or null if the
+        // project needs a fresh build (stale, missing, or the replay produced no succeeded results).
+        private static IReadOnlyList<IAnalyzerResult>? TryReplayCachedBinlog(
+            IAnalyzerManager manager,
+            HashSet<string> projectsNeedingRebuild,
+            string projectPath,
+            string projectName,
+            string binlogPath,
+            StreamCallbacks callbacks,
+            string buildLabel)
+        {
+            if (projectsNeedingRebuild.Contains(projectPath) || !File.Exists(binlogPath))
+            {
+                return null;
+            }
+            callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
+            var cached = RealTfmResults(manager.Analyze(binlogPath));
+            if (cached.Any(r => r.Succeeded))
+            {
+                // Project references are patched from the Roslyn workspace in the
+                // Load stage, which also overwrites the deps sidecar. Nothing to
+                // do here beyond signalling completion.
+                callbacks.OnBuildCompleted?.Invoke(projectPath);
+                return cached;
+            }
+            return null; // Stale or corrupted binlog — caller falls through to a fresh build.
+        }
+
+        // Runs up to MaxBuildAttempts fresh MSBuild invocations, deleting a bad binlog between
+        // retries. Returns results on the first successful attempt, or null after all attempts fail.
+        private static async Task<IReadOnlyList<IAnalyzerResult>?> RunFreshBuildLoopAsync(
+            IProjectAnalyzer p,
+            IAnalyzerManager manager,
+            string binlogPath,
+            string projectPath,
+            string projectName,
+            string projectFileName,
+            StreamCallbacks callbacks,
+            string buildLabel,
+            bool isScanPass,
+            string? buildLogDirectory)
+        {
             for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
             {
                 callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -191,7 +191,11 @@ namespace Strazh.Analysis
             if (cacheDirectory != null)
             {
                 Directory.CreateDirectory(cacheDirectory);
-                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+                projectsNeedingRebuild = noCache
+                    ? manager.Projects.Values
+                        .Select(p => p.ProjectFile.Path)
+                        .ToHashSet(StringComparer.OrdinalIgnoreCase)
+                    : ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
             }
 
             // Build stage: run MSBuild design-time builds in parallel, capped at the number

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -347,20 +347,41 @@ namespace Strazh.Analysis
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        IReadOnlyList<IAnalyzerResult> tfmResults;
+                        var projectPath = p.ProjectFile.Path;
+                        var projectName = GetProjectName(p.ProjectFile.Name);
+                        var projectFileName = Path.GetFileName(projectPath);
+
                         if (cacheDirectory != null)
                         {
                             var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path) || !File.Exists(binlogPath))
+
+                            // Cache-hit: replay the existing binlog; fall through to fresh build on failure.
+                            if (!projectsNeedingRebuild!.Contains(projectPath) && File.Exists(binlogPath))
                             {
-                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false, buildLabel);
-                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path, binlogPath));
+                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
+                                var cached = RealTfmResults(manager.Analyze(binlogPath));
+                                if (cached.Any(r => r.Succeeded))
+                                {
+                                    // Project references are patched from the Roslyn workspace in the
+                                    // Load stage, which also overwrites the deps sidecar. Nothing to
+                                    // do here beyond signalling completion.
+                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                                    return cached;
+                                }
+                                // Stale or corrupted cached binlog — fall through to a fresh build.
+                            }
+
+                            // Fresh-build retry loop (max MaxBuildAttempts attempts).
+                            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
+                            {
+                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
+                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath, binlogPath));
                                 if (timedOut)
                                 {
                                     if (isScanPass)
-                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                        callbacks.OnBuildCompleted?.Invoke(projectPath);
                                     else
-                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
+                                        callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build timed out");
                                     return null;
                                 }
                                 // Read from the binlog rather than the pipe result. The pipe uses
@@ -370,60 +391,66 @@ namespace Strazh.Analysis
                                 // by StructuredLogger, which handles the current format regardless of
                                 // version skew.
                                 var binlogExists = File.Exists(binlogPath);
-                                tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
-                                if (!tfmResults.Any(r => r.Succeeded))
+                                var tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
+                                if (tfmResults.Any(r => r.Succeeded))
                                 {
-                                    var reason = binlogExists ? "build log could not be read" : "build failed";
-                                    if (isScanPass)
-                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                                    else
-                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
-                                    return null;
+                                    // Write an initial deps sidecar with whatever project references
+                                    // MSBuild returned. Binlog replay often leaves this empty (MSBuild
+                                    // 17.14+ does not emit ProjectReferences into the replay). The Load
+                                    // stage patches from the Roslyn workspace and overwrites the file
+                                    // with the correct paths so subsequent staleness checks are accurate.
+                                    WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
+                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                                    return tfmResults;
                                 }
-                                // Write an initial deps sidecar with whatever project references
-                                // MSBuild returned. Binlog replay often leaves this empty (MSBuild
-                                // 17.14+ does not emit ProjectReferences into the replay). The Load
-                                // stage patches from the Roslyn workspace and overwrites the file
-                                // with the correct paths so subsequent staleness checks are accurate.
-                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
-                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                            }
-                            else
-                            {
-                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true, buildLabel);
-                                tfmResults = RealTfmResults(manager.Analyze(binlogPath));
-                                if (!tfmResults.Any(r => r.Succeeded))
+                                if (attempt < MaxBuildAttempts)
                                 {
-                                    var reason = "cached build log could not be read";
-                                    if (isScanPass)
-                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                                    else
-                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
-                                    return null;
+                                    if (binlogExists)
+                                    {
+                                        File.Delete(binlogPath);
+                                    }
+                                    continue;
                                 }
-                                // Project references are patched from the Roslyn workspace in the
-                                // Load stage, which also overwrites the deps sidecar. Nothing to
-                                // do here beyond signalling completion.
-                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                var reason = binlogExists ? "build log could not be read" : "build failed";
+                                if (isScanPass)
+                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                                else
+                                    callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, reason);
+                                return null;
                             }
                         }
                         else
                         {
-                            callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false, buildLabel);
-                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path));
-                            if (buildResults2 == null || !buildResults2.Any(r => r.Succeeded))
+                            // No cache — retry loop against pipe results.
+                            for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
                             {
-                                var reason = timedOut2 ? "build timed out" : "build failed";
+                                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
+                                var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath));
+                                if (timedOut2)
+                                {
+                                    if (isScanPass)
+                                        callbacks.OnBuildCompleted?.Invoke(projectPath);
+                                    else
+                                        callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build timed out");
+                                    return null;
+                                }
+                                if (buildResults2 != null && buildResults2.Any(r => r.Succeeded))
+                                {
+                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                                    return buildResults2;
+                                }
+                                if (attempt < MaxBuildAttempts)
+                                {
+                                    continue;
+                                }
                                 if (isScanPass)
-                                    callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                    callbacks.OnBuildCompleted?.Invoke(projectPath);
                                 else
-                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
+                                    callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, "build failed");
                                 return null;
                             }
-                            tfmResults = buildResults2;
-                            callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                         }
-                        return tfmResults;
+                        return null; // unreachable — loops always return
                     }
                     finally
                     {
@@ -437,6 +464,7 @@ namespace Strazh.Analysis
         // Task.Run continues to hold its thread until the process eventually exits or is reaped
         // when the parent process terminates — that is acceptable.
         private static readonly TimeSpan BuildTimeout = TimeSpan.FromMinutes(5);
+        private const int MaxBuildAttempts = 3;
 
         // Reads the binlog, retrying once after a short delay if the first attempt yields no
         // results. The MSBuild child process closes its stdout pipe (causing p.Build() to return)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -9,6 +9,7 @@ using Buildalyzer.Environment;
 using Buildalyzer.Workspaces;
 using System.Collections.Generic;
 using System;
+using System.Collections.Immutable;
 using Strazh.Database;
 using static Strazh.Analysis.AnalyzerConfig;
 using System.IO;
@@ -23,9 +24,13 @@ namespace Strazh.Analysis
         {
             Console.WriteLine($"Setup analyzer...");
 
+            Directory.CreateDirectory(config.BuildLogDirectory);
+            var buildalyzerLogPath = Path.Combine(config.BuildLogDirectory, $"buildalyzer-{DateTime.UtcNow:yyyy-MM-ddTHHmmssZ}.log");
+            using var buildalyzerLog = TextWriter.Synchronized(new StreamWriter(buildalyzerLogPath, append: false));
+            var managerOptions = new AnalyzerManagerOptions { LogWriter = buildalyzerLog };
             var manager = config.IsSolutionBased
-                ? new AnalyzerManager(config.Solution)
-                : new AnalyzerManager();
+                ? new AnalyzerManager(config.Solution, managerOptions)
+                : new AnalyzerManager(managerOptions);
 
             var projectAnalyzers = (config.IsSolutionBased
                 ? manager.Projects.Values
@@ -194,10 +199,10 @@ namespace Strazh.Analysis
                         if (cacheDirectory != null)
                         {
                             var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
+                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path) || !File.Exists(binlogPath))
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name), binlogPath));
+                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path, binlogPath));
                                 if (timedOut)
                                 {
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
@@ -217,30 +222,33 @@ namespace Strazh.Analysis
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
                                     return null;
                                 }
-                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded));
+                                // Write an initial deps sidecar with whatever project references
+                                // MSBuild returned. Binlog replay often leaves this empty (MSBuild
+                                // 17.14+ does not emit ProjectReferences into the replay). The Load
+                                // stage patches from the Roslyn workspace and overwrites the file
+                                // with the correct paths so subsequent staleness checks are accurate.
+                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                             else
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true);
-                                tfmResults = manager.Analyze(binlogPath).ToList();
+                                tfmResults = RealTfmResults(manager.Analyze(binlogPath));
                                 if (!tfmResults.Any(r => r.Succeeded))
                                 {
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "cached build log could not be read");
                                     return null;
                                 }
-                                // Keep the sidecar in sync with the binlog even on a cache hit.
-                                // Without this, a project whose build previously timed out (leaving
-                                // the deps file from an older run) would carry stale dependency
-                                // information into the next staleness-propagation pass.
-                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded));
+                                // Project references are patched from the Roslyn workspace in the
+                                // Load stage, which also overwrites the deps sidecar. Nothing to
+                                // do here beyond signalling completion.
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                         }
                         else
                         {
                             callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name)));
+                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path));
                             if (buildResults2 == null || !buildResults2.Any(r => r.Succeeded))
                             {
                                 var reason = timedOut2 ? "build timed out" : "build failed";
@@ -268,6 +276,18 @@ namespace Strazh.Analysis
             // path), so only the first TFM result is used to add the project to the workspace.
             // Each TFM result is then yielded with that shared workspace project so that
             // TFM-specific package/project references are each captured as triples.
+            //
+            // After AddToWorkspace, the Roslyn Project object carries the authoritative project
+            // references (resolved by MSBuild and stored in the workspace). We patch any
+            // IAnalyzerResult whose ProjectReferences is empty (e.g. from binlog replay) with
+            // these paths, then overwrite the deps sidecar so subsequent staleness checks work.
+            var binlogPathMap = cacheDirectory != null
+                ? manager.Projects.Values.ToDictionary(
+                    p => p.ProjectFile.Path,
+                    p => GetBinlogCachePath(cacheDirectory, p),
+                    StringComparer.OrdinalIgnoreCase)
+                : null;
+
             foreach (var tfmGroup in TopologicalSort(results))
             {
                 var primaryResult = tfmGroup.First(r => r.Succeeded);
@@ -287,7 +307,12 @@ namespace Strazh.Analysis
                         callbacks.OnProjectSkipped?.Invoke(primaryResult.ProjectFilePath, Path.GetFileName(primaryResult.ProjectFilePath), "unsupported project type");
                         continue;
                     }
-                    foreach (var result in tfmGroup)
+                    var patchedGroup = PatchProjectRefsFromWorkspace(tfmGroup, project, workspace);
+                    if (binlogPathMap != null && binlogPathMap.TryGetValue(primaryResult.ProjectFilePath, out var bp))
+                    {
+                        WriteDepsFile(bp, patchedGroup.First(r => r.Succeeded).ProjectReferences.ToList());
+                    }
+                    foreach (var result in patchedGroup)
                     {
                         yield return (project, result);
                     }
@@ -297,7 +322,12 @@ namespace Strazh.Analysis
                     // Already in the workspace because an earlier project pulled it in as a
                     // transitive reference. Still include it so it gets CONTAINS triples and
                     // is analyzed — just reuse the workspace Project object already there.
-                    foreach (var result in tfmGroup)
+                    var patchedGroup = PatchProjectRefsFromWorkspace(tfmGroup, existingProject, workspace);
+                    if (binlogPathMap != null && binlogPathMap.TryGetValue(primaryResult.ProjectFilePath, out var bp))
+                    {
+                        WriteDepsFile(bp, patchedGroup.First(r => r.Succeeded).ProjectReferences.ToList());
+                    }
+                    foreach (var result in patchedGroup)
                     {
                         yield return (existingProject, result);
                     }
@@ -362,20 +392,20 @@ namespace Strazh.Analysis
         // Returns all TFM results from the binlog (one per target framework for multi-target projects).
         private static async Task<IReadOnlyList<IAnalyzerResult>> TryAnalyzeBinlogAsync(IAnalyzerManager manager, string binlogPath)
         {
-            var results = manager.Analyze(binlogPath).ToList();
+            var results = RealTfmResults(manager.Analyze(binlogPath));
             if (results.Count > 0)
             {
                 return results;
             }
             await Task.Delay(500).ConfigureAwait(false);
-            return manager.Analyze(binlogPath).ToList();
+            return RealTfmResults(manager.Analyze(binlogPath));
         }
 
         private static async Task<(IReadOnlyList<IAnalyzerResult>? results, bool timedOut)> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
         {
             var buildTask = Task.Run<IReadOnlyList<IAnalyzerResult>?>(() =>
             {
-                var results = p.Build(opts).ToList();
+                var results = RealTfmResults(p.Build(opts));
                 return results.Count > 0 ? results : null;
             });
             if (await Task.WhenAny(buildTask, Task.Delay(BuildTimeout)).ConfigureAwait(false) != buildTask)
@@ -385,7 +415,29 @@ namespace Strazh.Analysis
             return (await buildTask.ConfigureAwait(false), timedOut: false);
         }
 
-        private static EnvironmentOptions CreateBuildOptions(string? buildLogDirectory, string projectName, string? binlogPath = null)
+        // Filters out entries that don't correspond to a real target-framework build.
+        //
+        // When building via p.Build(), MSBuild emits an outer evaluation result (TargetFramework="")
+        // plus one inner result per TFM (TargetFramework="netstandard2.1", etc.). For single-TFM
+        // projects the outer result also has Succeeded=true, so filtering by Succeeded alone
+        // returns two results per project instead of one.
+        //
+        // When replaying a binlog via manager.Analyze(), the TargetFramework property is not
+        // populated even for real TFM builds (it comes from an MSBuild property that isn't
+        // captured in the replay), so filtering by non-empty TargetFramework removes everything.
+        //
+        // Solution: prefer results with non-empty TargetFramework (inner TFM builds from p.Build()),
+        // and fall back to all Succeeded results only when none have a non-empty TargetFramework
+        // (the binlog-replay case). The Succeeded filter also handles multi-target projects where
+        // some TFMs fail and others succeed.
+        private static IReadOnlyList<IAnalyzerResult> RealTfmResults(IEnumerable<IAnalyzerResult> results)
+        {
+            var succeeded = results.Where(r => r.Succeeded).ToList();
+            var innerTfm = succeeded.Where(r => !string.IsNullOrEmpty(r.TargetFramework)).ToList();
+            return innerTfm.Count > 0 ? innerTfm : succeeded;
+        }
+
+        private static EnvironmentOptions CreateBuildOptions(string? buildLogDirectory, string projectFilePath, string? binlogPath = null)
         {
             var opts = new EnvironmentOptions();
             opts.Arguments.Add("/nodeReuse:false");
@@ -398,8 +450,11 @@ namespace Strazh.Analysis
             }
             if (buildLogDirectory != null)
             {
-                var logFile = Path.Combine(buildLogDirectory, $"{projectName}.log");
-                opts.Arguments.Add($"\"/fileLoggerParameters:LogFile={logFile};Verbosity=normal\"");
+                var displayName = GetProjectName(Path.GetFileName(projectFilePath));
+                var bytes = MD5.HashData(Encoding.UTF8.GetBytes(projectFilePath));
+                var hash = Convert.ToHexString(bytes)[..8];
+                var logFile = Path.Combine(buildLogDirectory, $"{displayName}_{hash}.log");
+                opts.Arguments.Add($"\"/fileLoggerParameters:LogFile={logFile};Verbosity=normal;Append\"");
             }
             return opts;
         }
@@ -409,7 +464,7 @@ namespace Strazh.Analysis
             var workspace = new AdhocWorkspace();
             if (!string.IsNullOrEmpty(manager.SolutionFilePath))
             {
-                SolutionInfo solutionInfo = SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
+                Microsoft.CodeAnalysis.SolutionInfo solutionInfo = Microsoft.CodeAnalysis.SolutionInfo.Create(SolutionId.CreateNewId(), VersionStamp.Default, manager.SolutionFilePath);
                 workspace.AddSolution(solutionInfo);
             }
             return workspace;
@@ -460,11 +515,11 @@ namespace Strazh.Analysis
             return false;
         }
 
-        // Writes the fully-evaluated project references from a build result as a sidecar next to
-        // the binlog. Subsequent runs read this instead of parsing the project file, so all
-        // MSBuild evaluation (conditions, imports, Directory.Build.props, etc.) is accounted for.
-        private static void WriteDepsFile(string binlogPath, IAnalyzerResult result) =>
-            File.WriteAllLines(binlogPath + ".deps", result.ProjectReferences);
+        // Writes the project references as a sidecar next to the binlog. The list comes from
+        // either the build result (preferred: fully MSBuild-evaluated) or a project-file parse
+        // fallback. Subsequent runs read this instead of re-evaluating the project file.
+        private static void WriteDepsFile(string binlogPath, IReadOnlyList<string> projectReferences) =>
+            File.WriteAllLines(binlogPath + ".deps", projectReferences);
 
         // Reads the deps sidecar written by a previous build. Returns empty when the file does
         // not exist (first run, or cache cleared) — the project will be stale for other reasons.
@@ -613,5 +668,54 @@ namespace Strazh.Analysis
 
         private static string GetRoot(string filePath)
             => filePath.Split(Path.DirectorySeparatorChar).Reverse().Skip(1).FirstOrDefault();
+
+        // If any result in the group already has project references, the group is returned
+        // unchanged. Otherwise, Roslyn's project reference graph (populated by AddToWorkspace)
+        // is used to derive the absolute .csproj paths and wrap each result so that graph
+        // triples and topological sort are correct on cached runs.
+        private static IReadOnlyList<IAnalyzerResult> PatchProjectRefsFromWorkspace(
+            IReadOnlyList<IAnalyzerResult> tfmGroup, Project roslynProject, AdhocWorkspace workspace)
+        {
+            if (tfmGroup.Any(r => r.ProjectReferences.Any()))
+                return tfmGroup;
+            var refPaths = roslynProject.ProjectReferences
+                .Select(pr => workspace.CurrentSolution.GetProject(pr.ProjectId)?.FilePath)
+                .OfType<string>()
+                .ToList();
+            if (refPaths.Count == 0)
+                return tfmGroup;
+            return tfmGroup
+                .Select(r => (IAnalyzerResult)new AnalyzerResultWithProjectRefs(r, refPaths))
+                .ToList();
+        }
+
+        // Wraps an IAnalyzerResult and overrides ProjectReferences with a caller-supplied list.
+        // Used to attach workspace-derived project reference paths to binlog results, which do
+        // not populate ProjectReferences during replay (MSBuild 17.14+ / .NET 10 SDK).
+        private sealed class AnalyzerResultWithProjectRefs(IAnalyzerResult inner, IReadOnlyList<string> projectReferences) : IAnalyzerResult
+        {
+            public IEnumerable<string> ProjectReferences => projectReferences;
+
+            // All other members delegate to the wrapped result.
+            public ProjectAnalyzer? Analyzer => inner.Analyzer;
+            public IReadOnlyDictionary<string, IProjectItem[]> Items => inner.Items;
+            public AnalyzerManager Manager => inner.Manager;
+            public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> PackageReferences => inner.PackageReferences;
+            public string ProjectFilePath => inner.ProjectFilePath;
+            public Guid ProjectGuid => inner.ProjectGuid;
+            public IReadOnlyDictionary<string, string> Properties => inner.Properties;
+            public string[] References => inner.References;
+            public ImmutableDictionary<string, ImmutableArray<string>> ReferenceAliases => inner.ReferenceAliases;
+            public string[] AnalyzerReferences => inner.AnalyzerReferences;
+            public string[] SourceFiles => inner.SourceFiles;
+            public bool Succeeded => inner.Succeeded;
+            public string TargetFramework => inner.TargetFramework;
+            public string[] PreprocessorSymbols => inner.PreprocessorSymbols;
+            public string[] AdditionalFiles => inner.AdditionalFiles;
+            public string Command => inner.Command;
+            public string CompilerFilePath => inner.CompilerFilePath;
+            public string[] CompilerArguments => inner.CompilerArguments;
+            public string? GetProperty(string name) => inner.GetProperty(name);
+        }
     }
 }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -64,7 +64,7 @@ namespace Strazh.Analysis
                 await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory,
                     new StreamCallbacks
                     {
-                        OnBuildStarted = (path, name, isCacheHit) => progress.OnBuildStarted(path, name, isCacheHit),
+                        OnBuildStarted = (path, name, isCacheHit, buildLabel) => progress.OnBuildStarted(path, name, isCacheHit, buildLabel),
                         OnBuildCompleted = path => progress.OnBuildCompleted(path),
                         OnProjectSkipped = (path, filename, reason) => progress.OnProjectSkipped(path, filename, reason)
                     }, config.NoCache, config.BuildLogDirectory))
@@ -158,7 +158,7 @@ namespace Strazh.Analysis
         // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private readonly struct StreamCallbacks
         {
-            public Action<string, string, bool>? OnBuildStarted { get; init; }
+            public Action<string, string, bool, string>? OnBuildStarted { get; init; }
             public Action<string>? OnBuildCompleted { get; init; }
             public Action<string, string, string>? OnProjectSkipped { get; init; }
         }
@@ -183,88 +183,31 @@ namespace Strazh.Analysis
                     : ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
             }
 
-            // Build stage: run MSBuild design-time builds in parallel, capped at the number
-            // of logical processors so we don't spawn an unbounded number of dotnet processes.
-            // Each project may target multiple frameworks; the build task returns all TFM results
-            // so each one can be analyzed independently. A project is considered successful if
-            // at least one TFM produces a result.
-            var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
-            IReadOnlyList<IAnalyzerResult>?[] results = await Task.WhenAll(
-                manager.Projects.Values.Select(p => Task.Run<IReadOnlyList<IAnalyzerResult>?>(async () =>
-                {
-                    await buildSemaphore.WaitAsync();
-                    try
-                    {
-                        IReadOnlyList<IAnalyzerResult> tfmResults;
-                        if (cacheDirectory != null)
-                        {
-                            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path) || !File.Exists(binlogPath))
-                            {
-                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path, binlogPath));
-                                if (timedOut)
-                                {
-                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
-                                    return null;
-                                }
-                                // Read from the binlog rather than the pipe result. The pipe uses
-                                // MsBuildPipeLogger, which may not support the event types emitted by
-                                // the SDK's MSBuild version, leaving the pipe result empty even on a
-                                // successful build. The binlog is written natively by MSBuild and read
-                                // by StructuredLogger, which handles the current format regardless of
-                                // version skew.
-                                var binlogExists = File.Exists(binlogPath);
-                                tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
-                                if (!tfmResults.Any(r => r.Succeeded))
-                                {
-                                    var reason = binlogExists ? "build log could not be read" : "build failed";
-                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
-                                    return null;
-                                }
-                                // Write an initial deps sidecar with whatever project references
-                                // MSBuild returned. Binlog replay often leaves this empty (MSBuild
-                                // 17.14+ does not emit ProjectReferences into the replay). The Load
-                                // stage patches from the Roslyn workspace and overwrites the file
-                                // with the correct paths so subsequent staleness checks are accurate.
-                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
-                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                            }
-                            else
-                            {
-                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true);
-                                tfmResults = RealTfmResults(manager.Analyze(binlogPath));
-                                if (!tfmResults.Any(r => r.Succeeded))
-                                {
-                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "cached build log could not be read");
-                                    return null;
-                                }
-                                // Project references are patched from the Roslyn workspace in the
-                                // Load stage, which also overwrites the deps sidecar. Nothing to
-                                // do here beyond signalling completion.
-                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                            }
-                        }
-                        else
-                        {
-                            callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path));
-                            if (buildResults2 == null || !buildResults2.Any(r => r.Succeeded))
-                            {
-                                var reason = timedOut2 ? "build timed out" : "build failed";
-                                callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
-                                return null;
-                            }
-                            tfmResults = buildResults2;
-                            callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
-                        }
-                        return tfmResults;
-                    }
-                    finally
-                    {
-                        buildSemaphore.Release();
-                    }
-                })));
+            // Scan pass: if any project is missing a .deps sidecar the dependency graph is
+            // incomplete, so we cannot reliably detect transitive staleness or know which
+            // projects are safe to build in parallel without their dependencies present.
+            // Build everything in parallel first (Scanning) to populate binlog cache and
+            // .deps files, then re-derive the rebuild set from the now-complete graph before
+            // the main build pass. On warm-cache runs all .deps files exist and this is skipped.
+            if (cacheDirectory != null && manager.Projects.Values.Any(
+                    p => !File.Exists(GetBinlogCachePath(cacheDirectory, p) + ".deps")))
+            {
+                await RunBuildStageAsync(manager, cacheDirectory, projectsNeedingRebuild,
+                    callbacks, "Scanning", isScanPass: true, buildLogDirectory);
+                // Re-derive the rebuild set without the noCache override — the scan pass
+                // just built everything fresh, so nothing should be considered stale.
+                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+            }
+
+            // Main build pass: run MSBuild design-time builds in parallel, capped at the
+            // number of logical processors. Each project may target multiple frameworks;
+            // the build task returns all TFM results so each one can be analyzed independently.
+            // A project is considered successful if at least one TFM produces a result.
+            // After a scan pass this is mostly cache replays (fast); on warm-cache runs it
+            // rebuilds only the stale subset.
+            IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(
+                manager, cacheDirectory, projectsNeedingRebuild,
+                callbacks, "Building", isScanPass: false, buildLogDirectory);
 
             // Load stage: add each completed result to the workspace and yield immediately,
             // so analysis can begin on each project without waiting for all to be loaded.
@@ -377,6 +320,116 @@ namespace Strazh.Analysis
             }
 
             return sorted;
+        }
+
+        // Runs all MSBuild builds in parallel (capped at logical-processor count) and returns
+        // one result slot per project (null for skipped/failed projects).
+        //
+        // buildLabel is forwarded to OnBuildStarted so the progress UI can distinguish
+        // "Scanning" (dependency-discovery pass) from "Building" (main pass).
+        //
+        // isScanPass suppresses OnProjectSkipped for failures: scan failures are pre-work
+        // noise that will be reported properly by the main pass. OnBuildCompleted is called
+        // instead so the active-display entry is cleared.
+        private static Task<IReadOnlyList<IAnalyzerResult>?[]> RunBuildStageAsync(
+            IAnalyzerManager manager,
+            string? cacheDirectory,
+            HashSet<string>? projectsNeedingRebuild,
+            StreamCallbacks callbacks,
+            string buildLabel,
+            bool isScanPass,
+            string? buildLogDirectory)
+        {
+            var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
+            return Task.WhenAll(
+                manager.Projects.Values.Select(p => Task.Run<IReadOnlyList<IAnalyzerResult>?>(async () =>
+                {
+                    await buildSemaphore.WaitAsync();
+                    try
+                    {
+                        IReadOnlyList<IAnalyzerResult> tfmResults;
+                        if (cacheDirectory != null)
+                        {
+                            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
+                            if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path) || !File.Exists(binlogPath))
+                            {
+                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false, buildLabel);
+                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path, binlogPath));
+                                if (timedOut)
+                                {
+                                    if (isScanPass)
+                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                    else
+                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
+                                    return null;
+                                }
+                                // Read from the binlog rather than the pipe result. The pipe uses
+                                // MsBuildPipeLogger, which may not support the event types emitted by
+                                // the SDK's MSBuild version, leaving the pipe result empty even on a
+                                // successful build. The binlog is written natively by MSBuild and read
+                                // by StructuredLogger, which handles the current format regardless of
+                                // version skew.
+                                var binlogExists = File.Exists(binlogPath);
+                                tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
+                                if (!tfmResults.Any(r => r.Succeeded))
+                                {
+                                    var reason = binlogExists ? "build log could not be read" : "build failed";
+                                    if (isScanPass)
+                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                    else
+                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
+                                    return null;
+                                }
+                                // Write an initial deps sidecar with whatever project references
+                                // MSBuild returned. Binlog replay often leaves this empty (MSBuild
+                                // 17.14+ does not emit ProjectReferences into the replay). The Load
+                                // stage patches from the Roslyn workspace and overwrites the file
+                                // with the correct paths so subsequent staleness checks are accurate.
+                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
+                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                            }
+                            else
+                            {
+                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true, buildLabel);
+                                tfmResults = RealTfmResults(manager.Analyze(binlogPath));
+                                if (!tfmResults.Any(r => r.Succeeded))
+                                {
+                                    var reason = "cached build log could not be read";
+                                    if (isScanPass)
+                                        callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                    else
+                                        callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
+                                    return null;
+                                }
+                                // Project references are patched from the Roslyn workspace in the
+                                // Load stage, which also overwrites the deps sidecar. Nothing to
+                                // do here beyond signalling completion.
+                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                            }
+                        }
+                        else
+                        {
+                            callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false, buildLabel);
+                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, p.ProjectFile.Path));
+                            if (buildResults2 == null || !buildResults2.Any(r => r.Succeeded))
+                            {
+                                var reason = timedOut2 ? "build timed out" : "build failed";
+                                if (isScanPass)
+                                    callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                                else
+                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
+                                return null;
+                            }
+                            tfmResults = buildResults2;
+                            callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
+                        }
+                        return tfmResults;
+                    }
+                    finally
+                    {
+                        buildSemaphore.Release();
+                    }
+                })));
         }
 
         // If a build hangs (e.g. Android/MAUI projects waiting on SDK tools not present in the

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -217,10 +217,12 @@ namespace Strazh.Analysis
                                 // successful build. The binlog is written natively by MSBuild and read
                                 // by StructuredLogger, which handles the current format regardless of
                                 // version skew.
-                                result = await TryAnalyzeBinlogAsync(manager, binlogPath);
+                                var binlogExists = File.Exists(binlogPath);
+                                result = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : null;
                                 if (result == null)
                                 {
-                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build failed");
+                                    var reason = binlogExists ? "build log could not be read" : "build failed";
+                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
                                     return null;
                                 }
                                 WriteDepsFile(binlogPath, result);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -62,7 +62,7 @@ namespace Strazh.Analysis
                         OnBuildStarted = (path, name, isCacheHit) => progress.OnBuildStarted(path, name, isCacheHit),
                         OnBuildCompleted = path => progress.OnBuildCompleted(path),
                         OnProjectSkipped = (path, filename, reason) => progress.OnProjectSkipped(path, filename, reason)
-                    }))
+                    }, config.NoCache, config.BuildLogDirectory))
                 {
                     var capturedEntry = entry;
                     var projectPath = capturedEntry.Item2.ProjectFilePath;

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -180,8 +180,13 @@ namespace Strazh.Analysis
 
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
             IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null,
-            StreamCallbacks callbacks = default)
+            StreamCallbacks callbacks = default, bool noCache = false, string? buildLogDirectory = null)
         {
+            if (buildLogDirectory != null)
+            {
+                Directory.CreateDirectory(buildLogDirectory);
+            }
+
             HashSet<string>? projectsNeedingRebuild = null;
             if (cacheDirectory != null)
             {
@@ -205,7 +210,7 @@ namespace Strazh.Analysis
                             if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(GetProjectName(p.ProjectFile.Name), binlogPath));
+                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name), binlogPath));
                                 if (timedOut)
                                 {
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
@@ -248,7 +253,7 @@ namespace Strazh.Analysis
                         else
                         {
                             callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                            var (buildResult2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(GetProjectName(p.ProjectFile.Name)));
+                            var (buildResult2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name)));
                             result = buildResult2;
                             if (result == null)
                             {
@@ -375,7 +380,7 @@ namespace Strazh.Analysis
             return (await buildTask.ConfigureAwait(false), timedOut: false);
         }
 
-        private static EnvironmentOptions CreateBuildOptions(string projectName, string? binlogPath = null)
+        private static EnvironmentOptions CreateBuildOptions(string? buildLogDirectory, string projectName, string? binlogPath = null)
         {
             var opts = new EnvironmentOptions();
             opts.Arguments.Add("/nodeReuse:false");
@@ -385,6 +390,11 @@ namespace Strazh.Analysis
                 // BinaryLogger on the host-side pipe, which can cause deserialization errors when the
                 // SDK's MSBuild version is newer than the MsBuildPipeLogger the host uses.
                 opts.Arguments.Add($"\"/bl:{binlogPath}\"");
+            }
+            if (buildLogDirectory != null)
+            {
+                var logFile = Path.Combine(buildLogDirectory, $"{projectName}.log");
+                opts.Arguments.Add($"\"/fileLoggerParameters:LogFile={logFile};Verbosity=normal\"");
             }
             return opts;
         }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -115,7 +115,7 @@ namespace Strazh.Analysis
 
             Console.WriteLine("Building projects - starting");
             
-            List<IAnalyzerResult> results = manager.Projects.Values
+            List<IAnalyzerResult?> results = manager.Projects.Values
                 .Select(p =>
                 {
                     Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
@@ -142,11 +142,21 @@ namespace Strazh.Analysis
             // Add each result to the new workspace (sorted in solution order above, if we have a solution)
             foreach (IAnalyzerResult result in results)
             {
-                // Check for duplicate project files and don't add them
-                if (workspace.CurrentSolution.Projects.All(p => p.FilePath != result.ProjectFilePath))
+                var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
+                if (existingProject is null)
                 {
+                    // AddToWorkspace with addProjectReferences: true eagerly adds referenced projects
+                    // into the workspace. Those will be picked up via existingProject on their own
+                    // loop iteration below.
                     var project = result.AddToWorkspace(workspace, true);
                     projectResults.Add((project, result));
+                }
+                else
+                {
+                    // Already in the workspace because an earlier project pulled it in as a
+                    // transitive reference. Still include it so it gets CONTAINS triples and
+                    // is analyzed — just reuse the workspace Project object already there.
+                    projectResults.Add((existingProject, result));
                 }
             }
 

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -148,31 +148,35 @@ namespace Strazh.Analysis
             return new AnalysisContext(workspace, projects);
         }
 
-        // Launches all MSBuild design-time builds in parallel (Build stage), then as each
-        // completes feeds it sequentially into the Roslyn AdhocWorkspace (Load stage), and
-        // yields the (Project, IAnalyzerResult) pair immediately — without waiting for all
-        // projects to finish first.
+        // Runs all MSBuild design-time builds in parallel (Build stage), waits for all to
+        // complete, then feeds results sequentially into the Roslyn AdhocWorkspace (Load stage),
+        // yielding each (Project, IAnalyzerResult) pair immediately so the Analyze and Insert
+        // stages can begin on each project without waiting for all projects to finish loading.
         //
-        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential while
-        // the underlying builds run concurrently on the thread pool.
+        // Build and Load cannot be interleaved: AddToWorkspace(addProjectReferences: true) calls
+        // analyzer.Build() internally for any referenced project not yet in the workspace. If
+        // other builds are still in-flight when this happens, two concurrent builds of the same
+        // project race and Buildalyzer's environment detection fails. Waiting for all builds to
+        // complete first avoids the race while still streaming Load → Analyze.
+        //
+        // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
             IAnalyzerManager manager, AdhocWorkspace workspace)
         {
-            // Build stage: launch all MSBuild design-time builds concurrently
-            List<Task<IAnalyzerResult?>> buildTasks = manager.Projects.Values
-                .Select(p => Task.Run<IAnalyzerResult?>(() =>
+            // Build stage: run all MSBuild design-time builds concurrently and wait for all
+            IAnalyzerResult?[] results = await Task.WhenAll(
+                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(() =>
                 {
                     Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
                     var result = p.Build().FirstOrDefault();
                     Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
                     return result;
-                }))
-                .ToList();
+                })));
 
-            // Load stage: as each build completes, add it to the workspace immediately
-            await foreach (var completedTask in Task.WhenEach(buildTasks))
+            // Load stage: add each completed result to the workspace and yield immediately,
+            // so analysis can begin on each project without waiting for all to be loaded
+            foreach (var result in results)
             {
-                var result = await completedTask;
                 if (result is null) continue;
 
                 Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -163,14 +163,24 @@ namespace Strazh.Analysis
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
             IAnalyzerManager manager, AdhocWorkspace workspace)
         {
-            // Build stage: run all MSBuild design-time builds concurrently and wait for all
+            // Build stage: run MSBuild design-time builds in parallel, capped at the number
+            // of logical processors so we don't spawn an unbounded number of dotnet processes
+            var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
             IAnalyzerResult?[] results = await Task.WhenAll(
-                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(() =>
+                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(async () =>
                 {
-                    Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
-                    var result = p.Build().FirstOrDefault();
-                    Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
-                    return result;
+                    await buildSemaphore.WaitAsync();
+                    try
+                    {
+                        Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                        var result = p.Build().FirstOrDefault();
+                        Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                        return result;
+                    }
+                    finally
+                    {
+                        buildSemaphore.Release();
+                    }
                 })));
 
             // Load stage: add each completed result to the workspace and yield immediately,

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -19,7 +19,7 @@ namespace Strazh.Analysis
 {
     public static class Analyzer
     {
-        public static async Task Analyze(AnalyzerConfig config, IAnalysisProgress progress)
+        public static async Task Analyze(AnalyzerConfig config, IAnalysisProgress progress, ITripleStore store)
         {
             Console.WriteLine($"Setup analyzer...");
 
@@ -37,17 +37,17 @@ namespace Strazh.Analysis
             // races against the delete.
             if (config.IsDelete)
             {
-                await DbManager.DeleteData(config.Credentials, config.Neo4jUrl);
+                await store.DeleteAllAsync();
             }
 
             // Ensure uniqueness constraints (and their implicit indexes) exist for every node
             // label before any MERGE operations run. Without indexes, each MERGE does a full
             // label scan and performance degrades linearly as the database grows.
-            await DbManager.EnsureIndexes(config.Credentials, config.Neo4jUrl);
+            await store.EnsureIndexesAsync();
 
             var workspace = CreateWorkspace(manager);
 
-            // Limit concurrent Neo4j connections to one per logical processor.
+            // Limit concurrent store connections to one per logical processor.
             var semaphore = new SemaphoreSlim(Environment.ProcessorCount);
             var analysisTasks = new List<Task>();
 
@@ -76,27 +76,7 @@ namespace Strazh.Analysis
 
                         if (config.IsSolutionBased)
                         {
-                            var solutionRoot = GetRoot(manager.SolutionFilePath);
-                            var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
-
-                            var solutionName = GetSolutionName(manager.SolutionFilePath);
-                            var solutionNode = new SolutionNode(solutionName);
-                            triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-
-                            // Connect the project's folder to the solution's root folder so the folder
-                            // hierarchy is traversable from the solution downward. Without this triple,
-                            // project folder nodes are orphans — present in the graph but unreachable
-                            // from the solution folder via INCLUDED_IN traversal.
-                            var projectRoot = capturedEntry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
-                            if (!string.IsNullOrEmpty(projectRoot) &&
-                                !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
-                            {
-                                var projectRootNode = new FolderNode(projectRoot, projectRoot);
-                                triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
-                            }
-
-                            var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
-                            triples.Add(new TripleContains(solutionNode, projectNode));
+                            triples.AddRange(GetSolutionAndRepositoryTriples(manager, capturedEntry));
                         }
 
                         var projectTriples = await AnalyzeProject(capturedEntry, config.Tier);
@@ -118,7 +98,7 @@ namespace Strazh.Analysis
                         await semaphore.WaitAsync();
                         try
                         {
-                            await DbManager.InsertData(triples, config.Credentials, config.Neo4jUrl);
+                            await store.InsertAsync(triples);
                         }
                         finally
                         {
@@ -514,6 +494,54 @@ namespace Strazh.Analysis
             } while (changed);
 
             return needsRebuild;
+        }
+
+        // Builds all triples for a solution and its associated git repository for a
+        // single project entry. Called once per project inside the parallel analysis tasks.
+        private static IList<Triple> GetSolutionAndRepositoryTriples(
+            IAnalyzerManager manager,
+            (Project project, IAnalyzerResult result) entry)
+        {
+            var triples = new List<Triple>();
+
+            var solutionRoot = GetRoot(manager.SolutionFilePath);
+            var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+
+            var solutionName = GetSolutionName(manager.SolutionFilePath);
+            var solutionNode = new SolutionNode(solutionName);
+            triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
+
+            // Repository: find the git root, read the remote origin URL, and emit a
+            // Folder(repoShortName) -INCLUDED_IN-> Repository(owner/repo) triple so the
+            // graph is rooted at the repository rather than an arbitrary local path.
+            var repoName = GitHelper.GetRepositoryName(manager.SolutionFilePath);
+            if (repoName != null)
+            {
+                var gitRoot = GitHelper.FindGitRoot(manager.SolutionFilePath);
+                var gitRootName = gitRoot != null
+                    ? Path.GetFileName(gitRoot)
+                    : repoName.Split('/').Last();
+                var repoRootFolderNode = new FolderNode(gitRootName, gitRootName);
+                var repoNode = new RepositoryNode(repoName);
+                triples.Add(new TripleIncludedIn(repoRootFolderNode, repoNode));
+            }
+
+            // Connect the project's folder to the solution's root folder so the folder
+            // hierarchy is traversable from the solution downward. Without this triple,
+            // project folder nodes are orphans — present in the graph but unreachable
+            // from the solution folder via INCLUDED_IN traversal.
+            var projectRoot = entry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
+            if (!string.IsNullOrEmpty(projectRoot) &&
+                !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
+            {
+                var projectRootNode = new FolderNode(projectRoot, projectRoot);
+                triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
+            }
+
+            var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
+            triples.Add(new TripleContains(solutionNode, projectNode));
+
+            return triples;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject((Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -18,7 +18,7 @@ namespace Strazh.Analysis
 {
     public static class Analyzer
     {
-        public static async Task Analyze(AnalyzerConfig config)
+        public static async Task Analyze(AnalyzerConfig config, IAnalysisProgress progress)
         {
             Console.WriteLine($"Setup analyzer...");
 
@@ -48,98 +48,89 @@ namespace Strazh.Analysis
 
             // Limit concurrent Neo4j connections to one per logical processor.
             var semaphore = new SemaphoreSlim(Environment.ProcessorCount);
-            var total = projectAnalyzers.Count;
-            var tasks = new List<Task>();
-            var index = 0;
+            var analysisTasks = new List<Task>();
 
             // Stream projects through the Build → Load pipeline and launch an Analyze + Insert
             // task for each one as soon as it becomes available, without waiting for all
             // projects to finish building and loading first.
-            await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory))
+            await progress.WrapAsync(projectAnalyzers.Count, async () =>
             {
-                var capturedEntry = entry;
-                var capturedIndex = index++;
-
-                tasks.Add(Task.Run(async () =>
+                await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory,
+                    new StreamCallbacks
+                    {
+                        OnBuildStarted = (path, name, isCacheHit) => progress.OnBuildStarted(path, name, isCacheHit),
+                        OnBuildCompleted = path => progress.OnBuildCompleted(path),
+                        OnProjectSkipped = (path, filename, reason) => progress.OnProjectSkipped(path, filename, reason)
+                    }))
                 {
-                    var triples = new List<Triple>();
+                    var capturedEntry = entry;
+                    var projectPath = capturedEntry.Item2.ProjectFilePath;
+                    var projectDisplayName = GetProjectName(capturedEntry.Item1.Name);
 
-                    if (config.IsSolutionBased)
+                    progress.OnStageChanged(projectPath, projectDisplayName, "Analyzing");
+
+                    analysisTasks.Add(Task.Run(async () =>
                     {
-                        var solutionRoot = GetRoot(manager.SolutionFilePath);
-                        var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
+                        var triples = new List<Triple>();
 
-                        var solutionName = GetSolutionName(manager.SolutionFilePath);
-                        var solutionNode = new SolutionNode(solutionName);
-                        triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-
-                        // Connect the project's folder to the solution's root folder so the folder
-                        // hierarchy is traversable from the solution downward. Without this triple,
-                        // project folder nodes are orphans — present in the graph but unreachable
-                        // from the solution folder via INCLUDED_IN traversal.
-                        var projectRoot = capturedEntry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
-                        if (!string.IsNullOrEmpty(projectRoot) &&
-                            !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
+                        if (config.IsSolutionBased)
                         {
-                            var projectRootNode = new FolderNode(projectRoot, projectRoot);
-                            triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
-                        }
+                            var solutionRoot = GetRoot(manager.SolutionFilePath);
+                            var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
 
-                        var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
-                        triples.Add(new TripleContains(solutionNode, projectNode));
-                    }
+                            var solutionName = GetSolutionName(manager.SolutionFilePath);
+                            var solutionNode = new SolutionNode(solutionName);
+                            triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
 
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - starting");
-                    var projectTriples = await AnalyzeProject(capturedIndex + 1, capturedEntry, config.Tier);
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: analyze - finished");
-
-                    triples.AddRange(projectTriples);
-
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - starting");
-                    try
-                    {
-                        triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
-                            .ToList();
-                    }
-                    catch (Exception)
-                    {
-                        Console.WriteLine("Error detected. Dumping detailed logging data.");
-                        Console.WriteLine("[");
-                        var first = true;
-                        foreach (var triple in triples)
-                        {
-                            if (!first)
+                            // Connect the project's folder to the solution's root folder so the folder
+                            // hierarchy is traversable from the solution downward. Without this triple,
+                            // project folder nodes are orphans — present in the graph but unreachable
+                            // from the solution folder via INCLUDED_IN traversal.
+                            var projectRoot = capturedEntry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
+                            if (!string.IsNullOrEmpty(projectRoot) &&
+                                !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
                             {
-                                Console.WriteLine(",");
+                                var projectRootNode = new FolderNode(projectRoot, projectRoot);
+                                triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
                             }
-                            Console.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
 
-                            first = false;
+                            var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
+                            triples.Add(new TripleContains(solutionNode, projectNode));
                         }
-                        if (triples.Any())
+
+                        var projectTriples = await AnalyzeProject(capturedEntry, config.Tier);
+                        triples.AddRange(projectTriples);
+
+                        progress.OnStageChanged(projectPath, projectDisplayName, "Grouping");
+                        try
                         {
-                            Console.WriteLine("");
+                            triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
+                                .ToList();
                         }
-                        Console.WriteLine("]");
-                        throw;
-                    }
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: grouping - finished");
+                        catch (Exception)
+                        {
+                            progress.OnGroupingError(projectDisplayName, triples);
+                            throw;
+                        }
 
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - starting");
-                    await semaphore.WaitAsync();
-                    try
-                    {
-                        await DbManager.InsertData(triples, config.Credentials);
-                    }
-                    finally
-                    {
-                        semaphore.Release();
-                    }
-                    Console.WriteLine($"+ [{capturedIndex + 1}/{total}] {capturedEntry.Item1.Name}: insert - finished");
-                }));
-            }
+                        progress.OnStageChanged(projectPath, projectDisplayName, "Inserting");
+                        await semaphore.WaitAsync();
+                        try
+                        {
+                            await DbManager.InsertData(triples, config.Credentials);
+                        }
+                        finally
+                        {
+                            semaphore.Release();
+                        }
 
-            await Task.WhenAll(tasks);
+                        progress.OnProjectCompleted(projectPath, triples.Count);
+                    }));
+                }
+
+                await Task.WhenAll(analysisTasks);
+            });
+
             workspace.Dispose();
         }
 
@@ -179,8 +170,16 @@ namespace Strazh.Analysis
         // complete first avoids the race while still streaming Load → Analyze.
         //
         // AdhocWorkspace is not thread-safe, so workspace mutations remain sequential.
+        private readonly struct StreamCallbacks
+        {
+            public Action<string, string, bool>? OnBuildStarted { get; init; }
+            public Action<string>? OnBuildCompleted { get; init; }
+            public Action<string, string, string>? OnProjectSkipped { get; init; }
+        }
+
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
-            IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null)
+            IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null,
+            StreamCallbacks callbacks = default)
         {
             HashSet<string>? projectsNeedingRebuild = null;
             if (cacheDirectory != null)
@@ -204,26 +203,27 @@ namespace Strazh.Analysis
                             var binlogPath = GetBinlogCachePath(cacheDirectory, p);
                             if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
                             {
-                                Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
                                 p.AddBinaryLogger(binlogPath);
                                 result = p.Build().FirstOrDefault();
                                 if (result != null)
                                 {
                                     WriteDepsFile(binlogPath, result);
                                 }
-                                Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                             else
                             {
-                                Console.WriteLine($"Build - {p.ProjectFile.Name} - cache hit");
+                                callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true);
                                 result = manager.Analyze(binlogPath).FirstOrDefault();
+                                callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                         }
                         else
                         {
-                            Console.WriteLine($"Build - {p.ProjectFile.Name} - starting");
+                            callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
                             result = p.Build().FirstOrDefault();
-                            Console.WriteLine($"Build - {p.ProjectFile.Name} - finished");
+                            callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                         }
                         return result;
                     }
@@ -234,15 +234,17 @@ namespace Strazh.Analysis
                 })));
 
             // Load stage: add each completed result to the workspace and yield immediately,
-            // so analysis can begin on each project without waiting for all to be loaded
-            foreach (var result in results)
+            // so analysis can begin on each project without waiting for all to be loaded.
+            // Results are sorted in dependency order so every project's references are already
+            // in the workspace when AddToWorkspace runs, preventing it from triggering redundant
+            // MSBuild builds for references it cannot find there yet.
+            foreach (var result in TopologicalSort(results))
             {
                 if (result is null)
                 {
                     continue;
                 }
 
-                Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - starting");
                 var existingProject = workspace.CurrentSolution.Projects
                     .FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
                 if (existingProject is null)
@@ -255,10 +257,9 @@ namespace Strazh.Analysis
                     {
                         // AddToWorkspace returns null for project types not supported by Roslyn
                         // (e.g. F# projects, native projects). Skip them — they cannot be analyzed.
-                        Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - skipped (unsupported project type)");
+                        callbacks.OnProjectSkipped?.Invoke(result.ProjectFilePath, Path.GetFileName(result.ProjectFilePath), "unsupported project type");
                         continue;
                     }
-                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
                     yield return (project, result);
                 }
                 else
@@ -266,10 +267,48 @@ namespace Strazh.Analysis
                     // Already in the workspace because an earlier project pulled it in as a
                     // transitive reference. Still include it so it gets CONTAINS triples and
                     // is analyzed — just reuse the workspace Project object already there.
-                    Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
                     yield return (existingProject, result);
                 }
             }
+        }
+
+        // Sorts build results so that every project appears after all of its project
+        // references that are also in the result set. Without this ordering,
+        // AddToWorkspace(addProjectReferences: true) encounters references not yet in
+        // the workspace and calls analyzer.Build() on them — bypassing our binlog cache
+        // and running full, sequential in-process MSBuild evaluations for each one.
+        // A DFS post-order traversal over the dependency graph produces the correct order.
+        private static IReadOnlyList<IAnalyzerResult> TopologicalSort(IAnalyzerResult?[] results)
+        {
+            var byPath = results
+                .Where(r => r is not null)
+                .ToDictionary(r => r!.ProjectFilePath, r => r!, StringComparer.OrdinalIgnoreCase);
+
+            var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var sorted = new List<IAnalyzerResult>(byPath.Count);
+
+            void Visit(IAnalyzerResult result)
+            {
+                if (!visited.Add(result.ProjectFilePath))
+                {
+                    return;
+                }
+                foreach (var refPath in result.ProjectReferences)
+                {
+                    if (byPath.TryGetValue(refPath, out var refResult))
+                    {
+                        Visit(refResult);
+                    }
+                }
+                sorted.Add(result);
+            }
+
+            foreach (var result in byPath.Values)
+            {
+                Visit(result);
+            }
+
+            return sorted;
         }
 
         private static AdhocWorkspace CreateWorkspace(IAnalyzerManager manager)
@@ -385,18 +424,15 @@ namespace Strazh.Analysis
             return needsRebuild;
         }
 
-        private static async Task<IList<Triple>> AnalyzeProject(int index, (Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)
+        private static async Task<IList<Triple>> AnalyzeProject((Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)
         {
-            Console.WriteLine($"Project #{index}:");
             var root = GetRoot(item.project.FilePath);
             var rootNode = new FolderNode(root, root);
             var projectName = GetProjectName(item.project.Name);
-            Console.WriteLine($"Analyzing {projectName} project...");
 
             var triples = new List<Triple>();
             if (mode == Tiers.All || mode == Tiers.Project)
             {
-                Console.WriteLine($"Analyzing Project tier...");
                 var projectNode = new ProjectNode(projectName);
                 triples.Add(new TripleIncludedIn(projectNode, rootNode));
                 item.projectAnalyzerResult.ProjectReferences.ToList().ForEach(x =>
@@ -410,13 +446,11 @@ namespace Strazh.Analysis
                     var node = new PackageNode(x.Key, x.Key, version);
                     triples.Add(new TripleDependsOnPackage(projectNode, node));
                 });
-                Console.WriteLine($"Analyzing Project tier complete.");
             }
 
             if (item.project.SupportsCompilation
                 && (mode == Tiers.All || mode == Tiers.Code))
             {
-                Console.WriteLine($"Analyzing Code tier...");
                 var compilation = await item.project.GetCompilationAsync();
                 var syntaxTreeRoot = compilation.SyntaxTrees.Where(x => !x.FilePath.Contains("obj"));
                 foreach (var st in syntaxTreeRoot)
@@ -425,10 +459,8 @@ namespace Strazh.Analysis
                     Extractor.AnalyzeTree<InterfaceDeclarationSyntax>(triples, st, sem, rootNode);
                     Extractor.AnalyzeTree<ClassDeclarationSyntax>(triples, st, sem, rootNode);
                 }
-                Console.WriteLine($"Analyzing Code tier complete.");
             }
 
-            Console.WriteLine($"Analyzing {projectName} project complete.");
             return triples;
         }
         

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -179,15 +179,18 @@ namespace Strazh.Analysis
             }
 
             // Build stage: run MSBuild design-time builds in parallel, capped at the number
-            // of logical processors so we don't spawn an unbounded number of dotnet processes
+            // of logical processors so we don't spawn an unbounded number of dotnet processes.
+            // Each project may target multiple frameworks; the build task returns all TFM results
+            // so each one can be analyzed independently. A project is considered successful if
+            // at least one TFM produces a result.
             var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
-            IAnalyzerResult?[] results = await Task.WhenAll(
-                manager.Projects.Values.Select(p => Task.Run<IAnalyzerResult?>(async () =>
+            IReadOnlyList<IAnalyzerResult>?[] results = await Task.WhenAll(
+                manager.Projects.Values.Select(p => Task.Run<IReadOnlyList<IAnalyzerResult>?>(async () =>
                 {
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        IAnalyzerResult? result;
+                        IReadOnlyList<IAnalyzerResult> tfmResults;
                         if (cacheDirectory != null)
                         {
                             var binlogPath = GetBinlogCachePath(cacheDirectory, p);
@@ -207,21 +210,21 @@ namespace Strazh.Analysis
                                 // by StructuredLogger, which handles the current format regardless of
                                 // version skew.
                                 var binlogExists = File.Exists(binlogPath);
-                                result = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : null;
-                                if (result == null)
+                                tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
+                                if (!tfmResults.Any(r => r.Succeeded))
                                 {
                                     var reason = binlogExists ? "build log could not be read" : "build failed";
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
                                     return null;
                                 }
-                                WriteDepsFile(binlogPath, result);
+                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded));
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                             else
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true);
-                                result = manager.Analyze(binlogPath).FirstOrDefault();
-                                if (result == null)
+                                tfmResults = manager.Analyze(binlogPath).ToList();
+                                if (!tfmResults.Any(r => r.Succeeded))
                                 {
                                     callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "cached build log could not be read");
                                     return null;
@@ -230,24 +233,24 @@ namespace Strazh.Analysis
                                 // Without this, a project whose build previously timed out (leaving
                                 // the deps file from an older run) would carry stale dependency
                                 // information into the next staleness-propagation pass.
-                                WriteDepsFile(binlogPath, result);
+                                WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded));
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                         }
                         else
                         {
                             callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                            var (buildResult2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name)));
-                            result = buildResult2;
-                            if (result == null)
+                            var (buildResults2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, GetProjectName(p.ProjectFile.Name)));
+                            if (buildResults2 == null || !buildResults2.Any(r => r.Succeeded))
                             {
                                 var reason = timedOut2 ? "build timed out" : "build failed";
                                 callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
                                 return null;
                             }
+                            tfmResults = buildResults2;
                             callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                         }
-                        return result;
+                        return tfmResults;
                     }
                     finally
                     {
@@ -260,36 +263,44 @@ namespace Strazh.Analysis
             // Results are sorted in dependency order so every project's references are already
             // in the workspace when AddToWorkspace runs, preventing it from triggering redundant
             // MSBuild builds for references it cannot find there yet.
-            foreach (var result in TopologicalSort(results))
+            //
+            // For multi-target projects all TFMs share the same ProjectId (derived from the file
+            // path), so only the first TFM result is used to add the project to the workspace.
+            // Each TFM result is then yielded with that shared workspace project so that
+            // TFM-specific package/project references are each captured as triples.
+            foreach (var tfmGroup in TopologicalSort(results))
             {
-                if (result is null)
-                {
-                    continue;
-                }
+                var primaryResult = tfmGroup.First(r => r.Succeeded);
 
                 var existingProject = workspace.CurrentSolution.Projects
-                    .FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
+                    .FirstOrDefault(p => p.FilePath == primaryResult.ProjectFilePath);
                 if (existingProject is null)
                 {
                     // AddToWorkspace with addProjectReferences: true eagerly adds referenced projects
                     // into the workspace. Those will be picked up via existingProject on their own
                     // iteration below.
-                    var project = result.AddToWorkspace(workspace, true);
+                    var project = primaryResult.AddToWorkspace(workspace, true);
                     if (project is null)
                     {
                         // AddToWorkspace returns null for project types not supported by Roslyn
                         // (e.g. F# projects, native projects). Skip them — they cannot be analyzed.
-                        callbacks.OnProjectSkipped?.Invoke(result.ProjectFilePath, Path.GetFileName(result.ProjectFilePath), "unsupported project type");
+                        callbacks.OnProjectSkipped?.Invoke(primaryResult.ProjectFilePath, Path.GetFileName(primaryResult.ProjectFilePath), "unsupported project type");
                         continue;
                     }
-                    yield return (project, result);
+                    foreach (var result in tfmGroup)
+                    {
+                        yield return (project, result);
+                    }
                 }
                 else
                 {
                     // Already in the workspace because an earlier project pulled it in as a
                     // transitive reference. Still include it so it gets CONTAINS triples and
                     // is analyzed — just reuse the workspace Project object already there.
-                    yield return (existingProject, result);
+                    foreach (var result in tfmGroup)
+                    {
+                        yield return (existingProject, result);
+                    }
                 }
             }
         }
@@ -300,34 +311,39 @@ namespace Strazh.Analysis
         // the workspace and calls analyzer.Build() on them — bypassing our binlog cache
         // and running full, sequential in-process MSBuild evaluations for each one.
         // A DFS post-order traversal over the dependency graph produces the correct order.
-        private static IReadOnlyList<IAnalyzerResult> TopologicalSort(IAnalyzerResult?[] results)
+        //
+        // For multi-target projects, all TFMs share the same file path and project
+        // references, so the first TFM result is used for dependency ordering and the
+        // full group is emitted together.
+        private static IReadOnlyList<IReadOnlyList<IAnalyzerResult>> TopologicalSort(IReadOnlyList<IAnalyzerResult>?[] results)
         {
             var byPath = results
                 .Where(r => r is not null)
-                .ToDictionary(r => r!.ProjectFilePath, r => r!, StringComparer.OrdinalIgnoreCase);
+                .ToDictionary(r => r!.First(x => x.Succeeded).ProjectFilePath, r => r!, StringComparer.OrdinalIgnoreCase);
 
             var visited = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
-            var sorted = new List<IAnalyzerResult>(byPath.Count);
+            var sorted = new List<IReadOnlyList<IAnalyzerResult>>(byPath.Count);
 
-            void Visit(IAnalyzerResult result)
+            void Visit(IReadOnlyList<IAnalyzerResult> tfmGroup)
             {
-                if (!visited.Add(result.ProjectFilePath))
+                var primaryResult = tfmGroup.First(r => r.Succeeded);
+                if (!visited.Add(primaryResult.ProjectFilePath))
                 {
                     return;
                 }
-                foreach (var refPath in result.ProjectReferences)
+                foreach (var refPath in primaryResult.ProjectReferences)
                 {
-                    if (byPath.TryGetValue(refPath, out var refResult))
+                    if (byPath.TryGetValue(refPath, out var refGroup))
                     {
-                        Visit(refResult);
+                        Visit(refGroup);
                     }
                 }
-                sorted.Add(result);
+                sorted.Add(tfmGroup);
             }
 
-            foreach (var result in byPath.Values)
+            foreach (var tfmGroup in byPath.Values)
             {
-                Visit(result);
+                Visit(tfmGroup);
             }
 
             return sorted;
@@ -343,20 +359,25 @@ namespace Strazh.Analysis
         // results. The MSBuild child process closes its stdout pipe (causing p.Build() to return)
         // before the BinaryLogger's file write is guaranteed to be fully flushed to disk. A single
         // retry covers the common case where the OS buffers have not yet been committed.
-        private static async Task<IAnalyzerResult?> TryAnalyzeBinlogAsync(IAnalyzerManager manager, string binlogPath)
+        // Returns all TFM results from the binlog (one per target framework for multi-target projects).
+        private static async Task<IReadOnlyList<IAnalyzerResult>> TryAnalyzeBinlogAsync(IAnalyzerManager manager, string binlogPath)
         {
-            var result = manager.Analyze(binlogPath).FirstOrDefault();
-            if (result is not null)
+            var results = manager.Analyze(binlogPath).ToList();
+            if (results.Count > 0)
             {
-                return result;
+                return results;
             }
             await Task.Delay(500).ConfigureAwait(false);
-            return manager.Analyze(binlogPath).FirstOrDefault();
+            return manager.Analyze(binlogPath).ToList();
         }
 
-        private static async Task<(IAnalyzerResult? result, bool timedOut)> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
+        private static async Task<(IReadOnlyList<IAnalyzerResult>? results, bool timedOut)> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
         {
-            var buildTask = Task.Run(() => p.Build(opts).FirstOrDefault());
+            var buildTask = Task.Run<IReadOnlyList<IAnalyzerResult>?>(() =>
+            {
+                var results = p.Build(opts).ToList();
+                return results.Count > 0 ? results : null;
+            });
             if (await Task.WhenAny(buildTask, Task.Delay(BuildTimeout)).ConfigureAwait(false) != buildTask)
             {
                 return (null, timedOut: true);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -421,7 +421,18 @@ namespace Strazh.Analysis
                 return null;
             }
             stage.Callbacks.OnBuildStarted?.Invoke(state.Identity.Path, state.Identity.Name, true, stage.BuildLabel);
-            var cached = RealTfmResults(stage.Manager.Analyze(state.BinlogPath));
+            IReadOnlyList<IAnalyzerResult> cached;
+            try
+            {
+                cached = RealTfmResults(stage.Manager.Analyze(state.BinlogPath));
+            }
+            catch (FileNotFoundException)
+            {
+                // File.Exists passed but the file was deleted by a concurrent task between the
+                // check and the read (e.g. another project's retry loop sharing the same binlog
+                // path due to a hash-prefix collision). Fall through to a fresh build.
+                return null;
+            }
             if (cached.Any(r => r.Succeeded))
             {
                 // Project references are patched from the Roslyn workspace in the
@@ -537,13 +548,28 @@ namespace Strazh.Analysis
         // Returns all TFM results from the binlog (one per target framework for multi-target projects).
         private static async Task<IReadOnlyList<IAnalyzerResult>> TryAnalyzeBinlogAsync(IAnalyzerManager manager, string binlogPath)
         {
-            var results = RealTfmResults(manager.Analyze(binlogPath));
+            IReadOnlyList<IAnalyzerResult> results;
+            try
+            {
+                results = RealTfmResults(manager.Analyze(binlogPath));
+            }
+            catch (FileNotFoundException)
+            {
+                return [];
+            }
             if (results.Count > 0)
             {
                 return results;
             }
             await Task.Delay(500).ConfigureAwait(false);
-            return RealTfmResults(manager.Analyze(binlogPath));
+            try
+            {
+                return RealTfmResults(manager.Analyze(binlogPath));
+            }
+            catch (FileNotFoundException)
+            {
+                return [];
+            }
         }
 
         private readonly record struct BuildOutcome(IReadOnlyList<IAnalyzerResult>? Results, bool TimedOut);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -61,13 +61,17 @@ namespace Strazh.Analysis
             // projects to finish building and loading first.
             await progress.WrapAsync(projectAnalyzers.Count, async () =>
             {
-                await foreach (var entry in StreamProjectsAsync(manager, workspace, config.CacheDirectory,
-                    new StreamCallbacks
-                    {
-                        OnBuildStarted = (path, name, isCacheHit, buildLabel) => progress.OnBuildStarted(path, name, isCacheHit, buildLabel),
-                        OnBuildCompleted = path => progress.OnBuildCompleted(path),
-                        OnProjectSkipped = (path, filename, reason) => progress.OnProjectSkipped(path, filename, reason)
-                    }, config.NoCache, config.BuildLogDirectory))
+                await foreach (var entry in StreamProjectsAsync(manager, workspace,
+                    new AnalysisOptions(
+                        new StreamCallbacks
+                        {
+                            OnBuildStarted = (path, name, isCacheHit, buildLabel) => progress.OnBuildStarted(path, name, isCacheHit, buildLabel),
+                            OnBuildCompleted = path => progress.OnBuildCompleted(path),
+                            OnProjectSkipped = (path, filename, reason) => progress.OnProjectSkipped(path, filename, reason)
+                        },
+                        config.CacheDirectory,
+                        config.NoCache,
+                        config.BuildLogDirectory)))
                 {
                     var capturedEntry = entry;
                     var projectPath = capturedEntry.Item2.ProjectFilePath;
@@ -136,7 +140,8 @@ namespace Strazh.Analysis
 
             var workspace = CreateWorkspace(manager);
             var projects = new List<(Project, IAnalyzerResult)>();
-            await foreach (var item in StreamProjectsAsync(manager, workspace, cacheDirectory))
+            await foreach (var item in StreamProjectsAsync(manager, workspace,
+                new AnalysisOptions(Callbacks: default, cacheDirectory, NoCache: false, BuildLogDirectory: null)))
             {
                 projects.Add(item);
             }
@@ -163,24 +168,50 @@ namespace Strazh.Analysis
             public Action<string, string, string>? OnProjectSkipped { get; init; }
         }
 
+        private readonly record struct AnalysisOptions(
+            StreamCallbacks Callbacks,
+            string? CacheDirectory,
+            bool NoCache,
+            string? BuildLogDirectory);
+
+        private readonly record struct CacheContext(
+            string Directory,
+            HashSet<string> ProjectsNeedingRebuild);
+
+        // Carries the full context for one build stage (Scanning or Building).
+        private readonly record struct BuildStageContext(
+            IAnalyzerManager Manager,
+            CacheContext? Cache,
+            StreamCallbacks Callbacks,
+            string BuildLabel,
+            bool IsScanPass,
+            string? BuildLogDirectory);
+
+        private readonly record struct ProjectIdentity(string Path, string Name, string FileName);
+
+        // Bundles the three values needed to build and track one project within a stage.
+        private readonly record struct ProjectBuildState(
+            IProjectAnalyzer Project,
+            ProjectIdentity Identity,
+            string BinlogPath);
+
         private static async IAsyncEnumerable<(Project, IAnalyzerResult)> StreamProjectsAsync(
-            IAnalyzerManager manager, AdhocWorkspace workspace, string? cacheDirectory = null,
-            StreamCallbacks callbacks = default, bool noCache = false, string? buildLogDirectory = null)
+            IAnalyzerManager manager, AdhocWorkspace workspace, AnalysisOptions options = default)
         {
-            if (buildLogDirectory != null)
+            if (options.BuildLogDirectory != null)
             {
-                Directory.CreateDirectory(buildLogDirectory);
+                Directory.CreateDirectory(options.BuildLogDirectory);
             }
 
             HashSet<string>? projectsNeedingRebuild = null;
-            if (cacheDirectory != null)
+            if (options.CacheDirectory != null)
             {
-                Directory.CreateDirectory(cacheDirectory);
-                projectsNeedingRebuild = noCache
+                Directory.CreateDirectory(options.CacheDirectory);
+                projectsNeedingRebuild = options.NoCache
                     ? manager.Projects.Values
                         .Select(p => p.ProjectFile.Path)
                         .ToHashSet(StringComparer.OrdinalIgnoreCase)
-                    : ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+                    : ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
             }
 
             // Scan pass: if any project is missing a .deps sidecar the dependency graph is
@@ -189,14 +220,15 @@ namespace Strazh.Analysis
             // Build everything in parallel first (Scanning) to populate binlog cache and
             // .deps files, then re-derive the rebuild set from the now-complete graph before
             // the main build pass. On warm-cache runs all .deps files exist and this is skipped.
-            if (cacheDirectory != null && manager.Projects.Values.Any(
-                    p => !File.Exists(GetBinlogCachePath(cacheDirectory, p) + ".deps")))
+            if (options.CacheDirectory != null && manager.Projects.Values.Any(
+                    p => !File.Exists(GetBinlogCachePath(options.CacheDirectory, p) + ".deps")))
             {
-                await RunBuildStageAsync(manager, cacheDirectory, projectsNeedingRebuild,
-                    callbacks, "Scanning", isScanPass: true, buildLogDirectory);
+                await RunBuildStageAsync(new BuildStageContext(
+                    manager, new CacheContext(options.CacheDirectory, projectsNeedingRebuild!),
+                    options.Callbacks, BuildLabel: "Scanning", IsScanPass: true, options.BuildLogDirectory));
                 // Re-derive the rebuild set without the noCache override — the scan pass
                 // just built everything fresh, so nothing should be considered stale.
-                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, cacheDirectory);
+                projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
             }
 
             // Main build pass: run MSBuild design-time builds in parallel, capped at the
@@ -205,9 +237,11 @@ namespace Strazh.Analysis
             // A project is considered successful if at least one TFM produces a result.
             // After a scan pass this is mostly cache replays (fast); on warm-cache runs it
             // rebuilds only the stale subset.
-            IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(
-                manager, cacheDirectory, projectsNeedingRebuild,
-                callbacks, "Building", isScanPass: false, buildLogDirectory);
+            CacheContext? mainCache = options.CacheDirectory != null
+                ? new CacheContext(options.CacheDirectory, projectsNeedingRebuild!)
+                : null;
+            IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(new BuildStageContext(
+                manager, mainCache, options.Callbacks, BuildLabel: "Building", IsScanPass: false, options.BuildLogDirectory));
 
             // Load stage: add each completed result to the workspace and yield immediately,
             // so analysis can begin on each project without waiting for all to be loaded.
@@ -224,10 +258,10 @@ namespace Strazh.Analysis
             // references (resolved by MSBuild and stored in the workspace). We patch any
             // IAnalyzerResult whose ProjectReferences is empty (e.g. from binlog replay) with
             // these paths, then overwrite the deps sidecar so subsequent staleness checks work.
-            var binlogPathMap = cacheDirectory != null
+            var binlogPathMap = options.CacheDirectory != null
                 ? manager.Projects.Values.ToDictionary(
                     p => p.ProjectFile.Path,
-                    p => GetBinlogCachePath(cacheDirectory, p),
+                    p => GetBinlogCachePath(options.CacheDirectory, p),
                     StringComparer.OrdinalIgnoreCase)
                 : null;
 
@@ -247,7 +281,7 @@ namespace Strazh.Analysis
                     {
                         // AddToWorkspace returns null for project types not supported by Roslyn
                         // (e.g. F# projects, native projects). Skip them — they cannot be analyzed.
-                        callbacks.OnProjectSkipped?.Invoke(primaryResult.ProjectFilePath, Path.GetFileName(primaryResult.ProjectFilePath), "unsupported project type");
+                        options.Callbacks.OnProjectSkipped?.Invoke(primaryResult.ProjectFilePath, Path.GetFileName(primaryResult.ProjectFilePath), "unsupported project type");
                         continue;
                     }
                     var patchedGroup = PatchProjectRefsFromWorkspace(tfmGroup, project, workspace);
@@ -331,24 +365,16 @@ namespace Strazh.Analysis
         // isScanPass suppresses OnProjectSkipped for failures: scan failures are pre-work
         // noise that will be reported properly by the main pass. OnBuildCompleted is called
         // instead so the active-display entry is cleared.
-        private static Task<IReadOnlyList<IAnalyzerResult>?[]> RunBuildStageAsync(
-            IAnalyzerManager manager,
-            string? cacheDirectory,
-            HashSet<string>? projectsNeedingRebuild,
-            StreamCallbacks callbacks,
-            string buildLabel,
-            bool isScanPass,
-            string? buildLogDirectory)
+        private static Task<IReadOnlyList<IAnalyzerResult>?[]> RunBuildStageAsync(BuildStageContext stage)
         {
             var buildSemaphore = new SemaphoreSlim(Environment.ProcessorCount);
             return Task.WhenAll(
-                manager.Projects.Values.Select(p => Task.Run<IReadOnlyList<IAnalyzerResult>?>(async () =>
+                stage.Manager.Projects.Values.Select(project => Task.Run<IReadOnlyList<IAnalyzerResult>?>(async () =>
                 {
                     await buildSemaphore.WaitAsync();
                     try
                     {
-                        return await BuildSingleProjectAsync(p, manager, cacheDirectory,
-                            projectsNeedingRebuild, callbacks, buildLabel, isScanPass, buildLogDirectory);
+                        return await BuildSingleProjectAsync(project, stage);
                     }
                     finally
                     {
@@ -358,75 +384,49 @@ namespace Strazh.Analysis
         }
 
         private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildSingleProjectAsync(
-            IProjectAnalyzer p,
-            IAnalyzerManager manager,
-            string? cacheDirectory,
-            HashSet<string>? projectsNeedingRebuild,
-            StreamCallbacks callbacks,
-            string buildLabel,
-            bool isScanPass,
-            string? buildLogDirectory)
+            IProjectAnalyzer project, BuildStageContext stage)
         {
-            var projectPath = p.ProjectFile.Path;
-            var projectName = GetProjectName(p.ProjectFile.Name);
-            var projectFileName = Path.GetFileName(projectPath);
-            if (cacheDirectory != null)
+            var identity = new ProjectIdentity(
+                project.ProjectFile.Path,
+                GetProjectName(project.ProjectFile.Name),
+                Path.GetFileName(project.ProjectFile.Path));
+            if (stage.Cache != null)
             {
-                return await BuildProjectWithCacheAsync(p, manager, cacheDirectory,
-                    projectsNeedingRebuild!, projectPath, projectName, projectFileName,
-                    callbacks, buildLabel, isScanPass, buildLogDirectory);
+                return await BuildProjectWithCacheAsync(project, identity, stage);
             }
-            return await BuildProjectWithoutCacheAsync(p, projectPath, projectName, projectFileName,
-                callbacks, buildLabel, isScanPass, buildLogDirectory);
+            return await BuildProjectWithoutCacheAsync(project, identity, stage);
         }
 
         private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildProjectWithCacheAsync(
-            IProjectAnalyzer p,
-            IAnalyzerManager manager,
-            string cacheDirectory,
-            HashSet<string> projectsNeedingRebuild,
-            string projectPath,
-            string projectName,
-            string projectFileName,
-            StreamCallbacks callbacks,
-            string buildLabel,
-            bool isScanPass,
-            string? buildLogDirectory)
+            IProjectAnalyzer project, ProjectIdentity identity, BuildStageContext stage)
         {
-            var binlogPath = GetBinlogCachePath(cacheDirectory, p);
-            var cached = TryReplayCachedBinlog(manager, projectsNeedingRebuild, projectPath, projectName,
-                binlogPath, callbacks, buildLabel);
+            var binlogPath = GetBinlogCachePath(stage.Cache!.Value.Directory, project);
+            var state = new ProjectBuildState(project, identity, binlogPath);
+            var cached = TryReplayCachedBinlog(state, stage);
             if (cached != null)
             {
                 return cached;
             }
-            return await RunFreshBuildLoopAsync(p, manager, binlogPath, projectPath, projectName, projectFileName,
-                callbacks, buildLabel, isScanPass, buildLogDirectory);
+            return await RunFreshBuildLoopAsync(state, stage);
         }
 
         // Attempts to replay a cached binlog. Returns the results on success, or null if the
         // project needs a fresh build (stale, missing, or the replay produced no succeeded results).
         private static IReadOnlyList<IAnalyzerResult>? TryReplayCachedBinlog(
-            IAnalyzerManager manager,
-            HashSet<string> projectsNeedingRebuild,
-            string projectPath,
-            string projectName,
-            string binlogPath,
-            StreamCallbacks callbacks,
-            string buildLabel)
+            ProjectBuildState state, BuildStageContext stage)
         {
-            if (projectsNeedingRebuild.Contains(projectPath) || !File.Exists(binlogPath))
+            if (stage.Cache!.Value.ProjectsNeedingRebuild.Contains(state.Identity.Path) || !File.Exists(state.BinlogPath))
             {
                 return null;
             }
-            callbacks.OnBuildStarted?.Invoke(projectPath, projectName, true, buildLabel);
-            var cached = RealTfmResults(manager.Analyze(binlogPath));
+            stage.Callbacks.OnBuildStarted?.Invoke(state.Identity.Path, state.Identity.Name, true, stage.BuildLabel);
+            var cached = RealTfmResults(stage.Manager.Analyze(state.BinlogPath));
             if (cached.Any(r => r.Succeeded))
             {
                 // Project references are patched from the Roslyn workspace in the
                 // Load stage, which also overwrites the deps sidecar. Nothing to
                 // do here beyond signalling completion.
-                callbacks.OnBuildCompleted?.Invoke(projectPath);
+                stage.Callbacks.OnBuildCompleted?.Invoke(state.Identity.Path);
                 return cached;
             }
             return null; // Stale or corrupted binlog — caller falls through to a fresh build.
@@ -435,24 +435,15 @@ namespace Strazh.Analysis
         // Runs up to MaxBuildAttempts fresh MSBuild invocations, deleting a bad binlog between
         // retries. Returns results on the first successful attempt, or null after all attempts fail.
         private static async Task<IReadOnlyList<IAnalyzerResult>?> RunFreshBuildLoopAsync(
-            IProjectAnalyzer p,
-            IAnalyzerManager manager,
-            string binlogPath,
-            string projectPath,
-            string projectName,
-            string projectFileName,
-            StreamCallbacks callbacks,
-            string buildLabel,
-            bool isScanPass,
-            string? buildLogDirectory)
+            ProjectBuildState state, BuildStageContext stage)
         {
             for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
             {
-                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
-                var outcome = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath, binlogPath));
+                stage.Callbacks.OnBuildStarted?.Invoke(state.Identity.Path, state.Identity.Name, false, stage.BuildLabel);
+                var outcome = await BuildWithTimeoutAsync(state.Project, CreateBuildOptions(stage.BuildLogDirectory, state.Identity.Path, binlogPath: state.BinlogPath));
                 if (outcome.TimedOut)
                 {
-                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build timed out");
+                    SignalBuildNotCompleted(state.Identity, reason: "build timed out", stage);
                     return null;
                 }
                 // Read from the binlog rather than the pipe result. The pipe uses
@@ -461,8 +452,8 @@ namespace Strazh.Analysis
                 // successful build. The binlog is written natively by MSBuild and read
                 // by StructuredLogger, which handles the current format regardless of
                 // version skew.
-                var binlogExists = File.Exists(binlogPath);
-                var tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(manager, binlogPath) : [];
+                var binlogExists = File.Exists(state.BinlogPath);
+                var tfmResults = binlogExists ? await TryAnalyzeBinlogAsync(stage.Manager, state.BinlogPath) : [];
                 if (tfmResults.Any(r => r.Succeeded))
                 {
                     // Write an initial deps sidecar with whatever project references
@@ -470,21 +461,21 @@ namespace Strazh.Analysis
                     // 17.14+ does not emit ProjectReferences into the replay). The Load
                     // stage patches from the Roslyn workspace and overwrites the file
                     // with the correct paths so subsequent staleness checks are accurate.
-                    WriteDepsFile(binlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
-                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                    WriteDepsFile(state.BinlogPath, tfmResults.First(r => r.Succeeded).ProjectReferences.ToList());
+                    stage.Callbacks.OnBuildCompleted?.Invoke(state.Identity.Path);
                     return tfmResults;
                 }
                 else if (attempt < MaxBuildAttempts)
                 {
                     if (binlogExists)
                     {
-                        File.Delete(binlogPath);
+                        File.Delete(state.BinlogPath);
                     }
                 }
                 else
                 {
                     var reason = binlogExists ? "build log could not be read" : "build failed";
-                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, reason);
+                    SignalBuildNotCompleted(state.Identity, reason, stage);
                     return null;
                 }
             }
@@ -492,48 +483,40 @@ namespace Strazh.Analysis
         }
 
         private static async Task<IReadOnlyList<IAnalyzerResult>?> BuildProjectWithoutCacheAsync(
-            IProjectAnalyzer p,
-            string projectPath,
-            string projectName,
-            string projectFileName,
-            StreamCallbacks callbacks,
-            string buildLabel,
-            bool isScanPass,
-            string? buildLogDirectory)
+            IProjectAnalyzer project, ProjectIdentity identity, BuildStageContext stage)
         {
             for (var attempt = 1; attempt <= MaxBuildAttempts; attempt++)
             {
-                callbacks.OnBuildStarted?.Invoke(projectPath, projectName, false, buildLabel);
-                var outcome = await BuildWithTimeoutAsync(p, CreateBuildOptions(buildLogDirectory, projectPath));
+                stage.Callbacks.OnBuildStarted?.Invoke(identity.Path, identity.Name, false, stage.BuildLabel);
+                var outcome = await BuildWithTimeoutAsync(project, CreateBuildOptions(stage.BuildLogDirectory, identity.Path));
                 if (outcome.TimedOut)
                 {
-                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build timed out");
+                    SignalBuildNotCompleted(identity, reason: "build timed out", stage);
                     return null;
                 }
                 if (outcome.Results != null && outcome.Results.Any(r => r.Succeeded))
                 {
-                    callbacks.OnBuildCompleted?.Invoke(projectPath);
+                    stage.Callbacks.OnBuildCompleted?.Invoke(identity.Path);
                     return outcome.Results;
                 }
                 if (attempt == MaxBuildAttempts)
                 {
-                    SignalBuildNotCompleted(callbacks, isScanPass, projectPath, projectFileName, "build failed");
+                    SignalBuildNotCompleted(identity, reason: "build failed", stage);
                     return null;
                 }
             }
             return null; // unreachable — loop always returns
         }
 
-        private static void SignalBuildNotCompleted(
-            StreamCallbacks callbacks, bool isScanPass, string projectPath, string projectFileName, string reason)
+        private static void SignalBuildNotCompleted(ProjectIdentity identity, string reason, BuildStageContext stage)
         {
-            if (isScanPass)
+            if (stage.IsScanPass)
             {
-                callbacks.OnBuildCompleted?.Invoke(projectPath);
+                stage.Callbacks.OnBuildCompleted?.Invoke(identity.Path);
             }
             else
             {
-                callbacks.OnProjectSkipped?.Invoke(projectPath, projectFileName, reason);
+                stage.Callbacks.OnProjectSkipped?.Invoke(identity.Path, identity.FileName, reason);
             }
         }
 
@@ -543,6 +526,8 @@ namespace Strazh.Analysis
         // when the parent process terminates — that is acceptable.
         private static readonly TimeSpan BuildTimeout = TimeSpan.FromMinutes(5);
         private const int MaxBuildAttempts = 3;
+        // MD5 produces 32 hex chars; 8 is enough to make collisions negligible across a solution.
+        private const int HashPrefixLength = 8;
 
         // Reads the binlog, retrying once after a short delay if the first attempt yields no
         // results. The MSBuild child process closes its stdout pipe (causing p.Build() to return)
@@ -562,16 +547,16 @@ namespace Strazh.Analysis
 
         private readonly record struct BuildOutcome(IReadOnlyList<IAnalyzerResult>? Results, bool TimedOut);
 
-        private static async Task<BuildOutcome> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
+        private static async Task<BuildOutcome> BuildWithTimeoutAsync(IProjectAnalyzer project, EnvironmentOptions opts)
         {
             var buildTask = Task.Run<IReadOnlyList<IAnalyzerResult>?>(() =>
             {
-                var results = RealTfmResults(p.Build(opts));
+                var results = RealTfmResults(project.Build(opts));
                 return results.Count > 0 ? results : null;
             });
             if (await Task.WhenAny(buildTask, Task.Delay(BuildTimeout)).ConfigureAwait(false) != buildTask)
             {
-                return new BuildOutcome(null, TimedOut: true);
+                return new BuildOutcome(Results: null, TimedOut: true);
             }
             return new BuildOutcome(await buildTask.ConfigureAwait(false), TimedOut: false);
         }
@@ -613,7 +598,7 @@ namespace Strazh.Analysis
             {
                 var displayName = GetProjectName(Path.GetFileName(projectFilePath));
                 var bytes = MD5.HashData(Encoding.UTF8.GetBytes(projectFilePath));
-                var hash = Convert.ToHexString(bytes)[..8];
+                var hash = Convert.ToHexString(bytes)[..HashPrefixLength];
                 var logFile = Path.Combine(buildLogDirectory, $"{displayName}_{hash}.log");
                 opts.Arguments.Add($"\"/fileLoggerParameters:LogFile={logFile};Verbosity=normal;Append\"");
             }
@@ -631,11 +616,11 @@ namespace Strazh.Analysis
             return workspace;
         }
 
-        private static string GetBinlogCachePath(string cacheDirectory, IProjectAnalyzer p)
+        private static string GetBinlogCachePath(string cacheDirectory, IProjectAnalyzer project)
         {
-            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(p.ProjectFile.Path));
-            var hash = Convert.ToHexString(bytes)[..8];
-            return Path.Combine(cacheDirectory, $"{p.ProjectFile.Name}_{hash}.binlog");
+            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(project.ProjectFile.Path));
+            var hash = Convert.ToHexString(bytes)[..HashPrefixLength];
+            return Path.Combine(cacheDirectory, $"{project.ProjectFile.Name}_{hash}.binlog");
         }
 
         // Returns true if no binlog exists, or if the binlog is older than any source or

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -225,7 +225,7 @@ namespace Strazh.Analysis
             {
                 await RunBuildStageAsync(new BuildStageContext(
                     manager, new CacheContext(options.CacheDirectory, projectsNeedingRebuild!),
-                    options.Callbacks, BuildLabel: "Scanning", IsScanPass: true, options.BuildLogDirectory));
+                    options.Callbacks, BuildLabel: "Building", IsScanPass: true, options.BuildLogDirectory));
                 // Re-derive the rebuild set without the noCache override — the scan pass
                 // just built everything fresh, so nothing should be considered stale.
                 projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
@@ -241,7 +241,7 @@ namespace Strazh.Analysis
                 ? new CacheContext(options.CacheDirectory, projectsNeedingRebuild!)
                 : null;
             IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(new BuildStageContext(
-                manager, mainCache, options.Callbacks, BuildLabel: "Building", IsScanPass: false, options.BuildLogDirectory));
+                manager, mainCache, options.Callbacks, BuildLabel: "Scanning", IsScanPass: false, options.BuildLogDirectory));
 
             // Load stage: add each completed result to the workspace and yield immediately,
             // so analysis can begin on each project without waiting for all to be loaded.
@@ -360,7 +360,7 @@ namespace Strazh.Analysis
         // one result slot per project (null for skipped/failed projects).
         //
         // buildLabel is forwarded to OnBuildStarted so the progress UI can distinguish
-        // "Scanning" (dependency-discovery pass) from "Building" (main pass).
+        // "Building" (dependency-discovery pass) from "Scanning" (main pass).
         //
         // isScanPass suppresses OnProjectSkipped for failures: scan failures are pre-work
         // noise that will be reported properly by the main pass. OnBuildCompleted is called

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -178,7 +178,7 @@ namespace Strazh.Analysis
             string Directory,
             HashSet<string> ProjectsNeedingRebuild);
 
-        // Carries the full context for one build stage (Building or Graphing).
+        // Carries the full context for one build stage (Building or PostBuild).
         private readonly record struct BuildStageContext(
             IAnalyzerManager Manager,
             CacheContext? Cache,
@@ -219,7 +219,7 @@ namespace Strazh.Analysis
             // projects are safe to build in parallel without their dependencies present.
             // Run full MSBuild invocations for all projects to populate the binlog cache and
             // .deps files, then re-derive the rebuild set from the now-complete graph before
-            // the Graphing pass. On warm-cache runs all .deps files exist and this is skipped.
+            // the PostBuild pass. On warm-cache runs all .deps files exist and this is skipped.
             if (options.CacheDirectory != null && manager.Projects.Values.Any(
                     p => !File.Exists(GetBinlogCachePath(options.CacheDirectory, p) + ".deps")))
             {
@@ -231,7 +231,7 @@ namespace Strazh.Analysis
                 projectsNeedingRebuild = ComputeProjectsNeedingRebuild(manager.Projects.Values, options.CacheDirectory);
             }
 
-            // Graphing pass: replays the binlog cache for each project (or runs a fresh MSBuild
+            // PostBuild pass: replays the binlog cache for each project (or runs a fresh MSBuild
             // build if the cache is stale), then loads the results into the Roslyn workspace for
             // triple extraction, grouping, and insertion into the graph database. Each project may
             // target multiple frameworks; results from all TFMs are analyzed independently.
@@ -242,7 +242,7 @@ namespace Strazh.Analysis
                 ? new CacheContext(options.CacheDirectory, projectsNeedingRebuild!)
                 : null;
             IReadOnlyList<IAnalyzerResult>?[] results = await RunBuildStageAsync(new BuildStageContext(
-                manager, mainCache, options.Callbacks, BuildLabel: BuildStageLabel.Graphing, IsScanPass: false, options.BuildLogDirectory));
+                manager, mainCache, options.Callbacks, BuildLabel: BuildStageLabel.PostBuild, IsScanPass: false, options.BuildLogDirectory));
 
             // Load stage: add each completed result to the workspace and yield immediately,
             // so analysis can begin on each project without waiting for all to be loaded.
@@ -361,7 +361,7 @@ namespace Strazh.Analysis
         // one result slot per project (null for skipped/failed projects).
         //
         // buildLabel is forwarded to OnBuildStarted so the progress UI can distinguish
-        // Building (dependency-discovery pass) from Graphing (knowledge-graph pass).
+        // Building (dependency-discovery pass) from PostBuild (post-build analysis pass).
         //
         // isScanPass suppresses OnProjectSkipped for failures: scan failures are pre-work
         // noise that will be reported properly by the main pass. OnBuildCompleted is called

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -1,3 +1,4 @@
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System.Linq;
@@ -36,8 +37,21 @@ namespace Strazh.Analysis
             Console.WriteLine("done.");
             
             Console.WriteLine("Analyzing workspace...");
-            
-            for (var index = 0; index < context.Projects.Count; index++)
+
+            // Delete graph data upfront before parallel analysis begins, so that no project
+            // races against the delete.
+            if (config.IsDelete)
+            {
+                await DbManager.DeleteData(config.Credentials);
+            }
+
+            // Limit concurrent Neo4j connections to avoid exhausting the connection pool.
+            var semaphore = new SemaphoreSlim(4);
+            var total = context.Projects.Count;
+
+            // Analyze and insert all projects concurrently. Task.Run ensures CPU-bound work
+            // (syntax tree walking) runs on thread-pool threads rather than the calling thread.
+            var tasks = context.Projects.Select((entry, index) => Task.Run(async () =>
             {
                 var triples = new List<Triple>();
 
@@ -45,28 +59,28 @@ namespace Strazh.Analysis
                 {
                     var solutionRoot = GetRoot(manager.SolutionFilePath);
                     var solutionRootNode = new FolderNode(solutionRoot, solutionRoot);
-                    
+
                     var solutionName = GetSolutionName(manager.SolutionFilePath);
                     var solutionNode = new SolutionNode(solutionName);
                     triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
-                    
-                    var projectNode = new ProjectNode(GetProjectName(context.Projects[index].Item1.Name));
+
+                    var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
                     triples.Add(new TripleContains(solutionNode, projectNode));
                 }
 
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: analyze - starting");
-                var projectTriples = await AnalyzeProject(index + 1, context.Projects[index], config.Tier);
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: analyze - finished");
-                
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - starting");
+                var projectTriples = await AnalyzeProject(index + 1, entry, config.Tier);
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: analyze - finished");
+
                 triples.AddRange(projectTriples);
-                
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: grouping - starting");
+
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - starting");
                 try
                 {
                     triples = triples.GroupBy(x => x.ToString()).Select(x => x.First()).OrderBy(x => x.NodeA.Label)
                         .ToList();
                 }
-                catch (Exception error)
+                catch (Exception)
                 {
                     Console.WriteLine("Error detected. Dumping detailed logging data.");
                     Console.WriteLine("[");
@@ -88,12 +102,22 @@ namespace Strazh.Analysis
                     Console.WriteLine("]");
                     throw;
                 }
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: grouping - finished");
-                
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: inserting - starting");
-                await DbManager.InsertData(triples, config.Credentials, config.IsDelete && index == 0);
-                Console.WriteLine($"+ [{index + 1}/{context.Projects.Count} {context.Projects[index].Item1.Name}: inserting - finished");
-            }
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: grouping - finished");
+
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - starting");
+                await semaphore.WaitAsync();
+                try
+                {
+                    await DbManager.InsertData(triples, config.Credentials);
+                }
+                finally
+                {
+                    semaphore.Release();
+                }
+                Console.WriteLine($"+ [{index + 1}/{total}] {entry.Item1.Name}: inserting - finished");
+            })).ToList();
+
+            await Task.WhenAll(tasks);
             context.Workspace.Dispose();
         }
 
@@ -115,7 +139,10 @@ namespace Strazh.Analysis
 
             Console.WriteLine("Building projects - starting");
             
+            // Build projects in parallel — each invocation spawns an isolated MSBuild process
+            // so there is no shared mutable state between concurrent builds.
             List<IAnalyzerResult?> results = manager.Projects.Values
+                .AsParallel()
                 .Select(p =>
                 {
                     Console.WriteLine($"Building projects - {p.ProjectFile.Name} - starting");
@@ -139,7 +166,8 @@ namespace Strazh.Analysis
                 results = [.. results.OrderBy(p => projectsInOrder.FindIndex(g => g.AbsolutePath == p.ProjectFilePath))];
             }
 
-            // Add each result to the new workspace (sorted in solution order above, if we have a solution)
+            // Add each result to the new workspace (sorted in solution order above, if we have a solution).
+            // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
             foreach (IAnalyzerResult result in results)
             {
                 var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -168,8 +168,10 @@ namespace Strazh.Analysis
 
             // Add each result to the new workspace (sorted in solution order above, if we have a solution).
             // AdhocWorkspace mutations are not thread-safe, so this loop remains sequential.
+            Console.WriteLine("Loading projects into workspace - starting");
             foreach (IAnalyzerResult result in results)
             {
+                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - starting");
                 var existingProject = workspace.CurrentSolution.Projects.FirstOrDefault(p => p.FilePath == result.ProjectFilePath);
                 if (existingProject is null)
                 {
@@ -186,7 +188,9 @@ namespace Strazh.Analysis
                     // is analyzed — just reuse the workspace Project object already there.
                     projectResults.Add((existingProject, result));
                 }
+                Console.WriteLine($"Loading projects into workspace - {Path.GetFileName(result.ProjectFilePath)} - finished");
             }
+            Console.WriteLine("Loading projects into workspace - finished");
 
             return new AnalysisContext(workspace, projectResults.ToList());
         }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -747,6 +747,12 @@ namespace Strazh.Analysis
 
         // Builds all triples for a solution and its associated git repository for a
         // single project entry. Called once per project inside the parallel analysis tasks.
+        //
+        // Each project is attributed to its OWN git repository (which may be a submodule
+        // of the solution's repo), not the solution's. This keeps the graph stable across
+        // scans: scanning a submodule directly and scanning a host repo that includes it
+        // both produce identical Folder PKs and Repository associations for the submodule's
+        // contents, so a folder containing a submodule project is never tied to the host repo.
         private static IList<Triple> GetSolutionAndRepositoryTriples(
             IAnalyzerManager manager,
             (Project project, IAnalyzerResult result) entry)
@@ -760,37 +766,73 @@ namespace Strazh.Analysis
             var solutionNode = new SolutionNode(solutionName);
             triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
 
-            // Repository: find the git root, read the remote origin URL, and emit a
-            // Folder(repoShortName) -INCLUDED_IN-> Repository(owner/repo) triple so the
-            // graph is rooted at the repository rather than an arbitrary local path.
-            var repoName = GitHelper.GetRepositoryName(manager.SolutionFilePath);
-            if (repoName != null)
+            // Host repository root folder. Naming uses the natural repo name from origin
+            // (last segment of "owner/repo") rather than the local clone's directory
+            // basename, so PKs stay stable regardless of where the user cloned the repo.
+            var solutionRepoName = GitHelper.GetRepositoryName(manager.SolutionFilePath);
+            var solutionGitRoot = GitHelper.FindGitRoot(manager.SolutionFilePath);
+            var solutionRepoFolder = solutionRepoName != null
+                ? AttachRepoRoot(triples, solutionRepoName)
+                : null;
+
+            // Submodule mount points declared in the host repo's .gitmodules: a
+            // Folder(kind=Submodule) at "<host>/<mountPath>", INCLUDED_IN both the host's
+            // repo-root folder and the referenced Repository node.
+            if (solutionRepoFolder != null)
             {
-                var gitRoot = GitHelper.FindGitRoot(manager.SolutionFilePath);
-                var gitRootName = gitRoot != null
-                    ? Path.GetFileName(gitRoot)
-                    : repoName.Split('/').Last();
-                var repoRootFolderNode = new FolderNode(gitRootName, gitRootName);
-                var repoNode = new RepositoryNode(repoName);
-                triples.Add(new TripleIncludedIn(repoRootFolderNode, repoNode));
+                foreach (var sub in GitHelper.GetSubmodules(manager.SolutionFilePath))
+                {
+                    var mountPath = sub.MountPath.Replace('\\', '/');
+                    var mountFolder = new FolderNode(
+                        $"{solutionRepoFolder.Name}/{mountPath}",
+                        Path.GetFileName(mountPath),
+                        FolderKind.Submodule);
+                    triples.Add(new TripleIncludedIn(mountFolder, solutionRepoFolder));
+                    triples.Add(new TripleIncludedIn(mountFolder, new RepositoryNode(sub.RepositoryName)));
+                }
             }
 
-            // Connect the project's folder to the solution's root folder so the folder
-            // hierarchy is traversable from the solution downward. Without this triple,
-            // project folder nodes are orphans — present in the graph but unreachable
-            // from the solution folder via INCLUDED_IN traversal.
-            var projectRoot = entry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
-            if (!string.IsNullOrEmpty(projectRoot) &&
-                !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
+            // The project's own git root determines its repository. For a project living
+            // inside a submodule, this is the submodule's git root — not the solution's.
+            var projectPath = entry.Item1.FilePath;
+            var projectGitRoot = projectPath != null ? GitHelper.FindGitRoot(projectPath) : null;
+            var projectRepoName = projectPath != null ? GitHelper.GetRepositoryName(projectPath) : null;
+            var projectIsInSubmodule = projectGitRoot != null
+                && solutionGitRoot != null
+                && !projectGitRoot.Equals(solutionGitRoot, StringComparison.OrdinalIgnoreCase);
+
+            var projectRoot = projectPath != null ? GetRoot(projectPath) : null;
+            if (!string.IsNullOrEmpty(projectRoot))
             {
                 var projectRootNode = new FolderNode(projectRoot, projectRoot);
-                triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
+                // Submodule project → attach to its own repo's root folder. Host project →
+                // attach to the solution root (existing behavior). If we can't identify
+                // the submodule's repo, leave the folder un-attached rather than misattributing.
+                var parentFolder = projectIsInSubmodule
+                    ? (projectRepoName != null ? AttachRepoRoot(triples, projectRepoName) : null)
+                    : solutionRootNode;
+                if (parentFolder != null
+                    && !projectRoot.Equals(parentFolder.Name, StringComparison.OrdinalIgnoreCase))
+                {
+                    triples.Add(new TripleIncludedIn(projectRootNode, parentFolder));
+                }
             }
 
             var projectNode = new ProjectNode(GetProjectName(entry.Item1.Name));
             triples.Add(new TripleContains(solutionNode, projectNode));
 
             return triples;
+        }
+
+        // Emits Folder(<natural-repo-name>) -INCLUDED_IN-> Repository(<owner/repo>) and
+        // returns the folder. The folder name comes from the last segment of the repo
+        // name, so PKs are stable regardless of local clone directory naming.
+        private static FolderNode AttachRepoRoot(List<Triple> triples, string repoName)
+        {
+            var folderName = Path.GetFileName(repoName);
+            var folder = new FolderNode(folderName, folderName);
+            triples.Add(new TripleIncludedIn(folder, new RepositoryNode(repoName)));
+            return folder;
         }
 
         private static async Task<IList<Triple>> AnalyzeProject((Project project, IAnalyzerResult projectAnalyzerResult) item, Tiers mode)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -216,6 +216,16 @@ namespace Strazh.Analysis
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), true);
                                 result = manager.Analyze(binlogPath).FirstOrDefault();
+                                if (result == null)
+                                {
+                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "cached build log could not be read");
+                                    return null;
+                                }
+                                // Keep the sidecar in sync with the binlog even on a cache hit.
+                                // Without this, a project whose build previously timed out (leaving
+                                // the deps file from an older run) would carry stale dependency
+                                // information into the next staleness-propagation pass.
+                                WriteDepsFile(binlogPath, result);
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                         }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -68,6 +68,18 @@ namespace Strazh.Analysis
                         var solutionNode = new SolutionNode(solutionName);
                         triples.Add(new TripleIncludedIn(solutionNode, solutionRootNode));
 
+                        // Connect the project's folder to the solution's root folder so the folder
+                        // hierarchy is traversable from the solution downward. Without this triple,
+                        // project folder nodes are orphans — present in the graph but unreachable
+                        // from the solution folder via INCLUDED_IN traversal.
+                        var projectRoot = capturedEntry.Item1.FilePath is { } fp ? GetRoot(fp) : null;
+                        if (!string.IsNullOrEmpty(projectRoot) &&
+                            !projectRoot.Equals(solutionRoot, StringComparison.OrdinalIgnoreCase))
+                        {
+                            var projectRootNode = new FolderNode(projectRoot, projectRoot);
+                            triples.Add(new TripleIncludedIn(projectRootNode, solutionRootNode));
+                        }
+
                         var projectNode = new ProjectNode(GetProjectName(capturedEntry.Item1.Name));
                         triples.Add(new TripleContains(solutionNode, projectNode));
                     }
@@ -234,6 +246,13 @@ namespace Strazh.Analysis
                     // into the workspace. Those will be picked up via existingProject on their own
                     // iteration below.
                     var project = result.AddToWorkspace(workspace, true);
+                    if (project is null)
+                    {
+                        // AddToWorkspace returns null for project types not supported by Roslyn
+                        // (e.g. F# projects, native projects). Skip them — they cannot be analyzed.
+                        Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - skipped (unsupported project type)");
+                        continue;
+                    }
                     Console.WriteLine($"Load - {Path.GetFileName(result.ProjectFilePath)} - finished");
                     yield return (project, result);
                 }

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Microsoft.CodeAnalysis;
 using Strazh.Domain;
 using Buildalyzer;
+using Buildalyzer.Environment;
 using Buildalyzer.Workspaces;
 using System.Collections.Generic;
 using System;
@@ -204,12 +205,25 @@ namespace Strazh.Analysis
                             if (projectsNeedingRebuild!.Contains(p.ProjectFile.Path))
                             {
                                 callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                                p.AddBinaryLogger(binlogPath);
-                                result = p.Build().FirstOrDefault();
-                                if (result != null)
+                                var (_, timedOut) = await BuildWithTimeoutAsync(p, CreateBuildOptions(GetProjectName(p.ProjectFile.Name), binlogPath));
+                                if (timedOut)
                                 {
-                                    WriteDepsFile(binlogPath, result);
+                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build timed out");
+                                    return null;
                                 }
+                                // Read from the binlog rather than the pipe result. The pipe uses
+                                // MsBuildPipeLogger, which may not support the event types emitted by
+                                // the SDK's MSBuild version, leaving the pipe result empty even on a
+                                // successful build. The binlog is written natively by MSBuild and read
+                                // by StructuredLogger, which handles the current format regardless of
+                                // version skew.
+                                result = await TryAnalyzeBinlogAsync(manager, binlogPath);
+                                if (result == null)
+                                {
+                                    callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), "build failed");
+                                    return null;
+                                }
+                                WriteDepsFile(binlogPath, result);
                                 callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                             }
                             else
@@ -232,7 +246,14 @@ namespace Strazh.Analysis
                         else
                         {
                             callbacks.OnBuildStarted?.Invoke(p.ProjectFile.Path, GetProjectName(p.ProjectFile.Name), false);
-                            result = p.Build().FirstOrDefault();
+                            var (buildResult2, timedOut2) = await BuildWithTimeoutAsync(p, CreateBuildOptions(GetProjectName(p.ProjectFile.Name)));
+                            result = buildResult2;
+                            if (result == null)
+                            {
+                                var reason = timedOut2 ? "build timed out" : "build failed";
+                                callbacks.OnProjectSkipped?.Invoke(p.ProjectFile.Path, Path.GetFileName(p.ProjectFile.Path), reason);
+                                return null;
+                            }
                             callbacks.OnBuildCompleted?.Invoke(p.ProjectFile.Path);
                         }
                         return result;
@@ -319,6 +340,51 @@ namespace Strazh.Analysis
             }
 
             return sorted;
+        }
+
+        // If a build hangs (e.g. Android/MAUI projects waiting on SDK tools not present in the
+        // environment), WhenAny returns after the timeout and we skip the project. The underlying
+        // Task.Run continues to hold its thread until the process eventually exits or is reaped
+        // when the parent process terminates — that is acceptable.
+        private static readonly TimeSpan BuildTimeout = TimeSpan.FromMinutes(5);
+
+        // Reads the binlog, retrying once after a short delay if the first attempt yields no
+        // results. The MSBuild child process closes its stdout pipe (causing p.Build() to return)
+        // before the BinaryLogger's file write is guaranteed to be fully flushed to disk. A single
+        // retry covers the common case where the OS buffers have not yet been committed.
+        private static async Task<IAnalyzerResult?> TryAnalyzeBinlogAsync(IAnalyzerManager manager, string binlogPath)
+        {
+            var result = manager.Analyze(binlogPath).FirstOrDefault();
+            if (result is not null)
+            {
+                return result;
+            }
+            await Task.Delay(500).ConfigureAwait(false);
+            return manager.Analyze(binlogPath).FirstOrDefault();
+        }
+
+        private static async Task<(IAnalyzerResult? result, bool timedOut)> BuildWithTimeoutAsync(IProjectAnalyzer p, EnvironmentOptions opts)
+        {
+            var buildTask = Task.Run(() => p.Build(opts).FirstOrDefault());
+            if (await Task.WhenAny(buildTask, Task.Delay(BuildTimeout)).ConfigureAwait(false) != buildTask)
+            {
+                return (null, timedOut: true);
+            }
+            return (await buildTask.ConfigureAwait(false), timedOut: false);
+        }
+
+        private static EnvironmentOptions CreateBuildOptions(string projectName, string? binlogPath = null)
+        {
+            var opts = new EnvironmentOptions();
+            opts.Arguments.Add("/nodeReuse:false");
+            if (binlogPath != null)
+            {
+                // MSBuild writes the binlog directly in the child process. This avoids running the
+                // BinaryLogger on the host-side pipe, which can cause deserialization errors when the
+                // SDK's MSBuild version is newer than the MsBuildPipeLogger the host uses.
+                opts.Arguments.Add($"\"/bl:{binlogPath}\"");
+            }
+            return opts;
         }
 
         private static AdhocWorkspace CreateWorkspace(IAnalyzerManager manager)

--- a/Strazh/Analysis/Analyzer.cs
+++ b/Strazh/Analysis/Analyzer.cs
@@ -37,13 +37,13 @@ namespace Strazh.Analysis
             // races against the delete.
             if (config.IsDelete)
             {
-                await DbManager.DeleteData(config.Credentials);
+                await DbManager.DeleteData(config.Credentials, config.Neo4jUrl);
             }
 
             // Ensure uniqueness constraints (and their implicit indexes) exist for every node
             // label before any MERGE operations run. Without indexes, each MERGE does a full
             // label scan and performance degrades linearly as the database grows.
-            await DbManager.EnsureIndexes(config.Credentials);
+            await DbManager.EnsureIndexes(config.Credentials, config.Neo4jUrl);
 
             var workspace = CreateWorkspace(manager);
 
@@ -118,7 +118,7 @@ namespace Strazh.Analysis
                         await semaphore.WaitAsync();
                         try
                         {
-                            await DbManager.InsertData(triples, config.Credentials);
+                            await DbManager.InsertData(triples, config.Credentials, config.Neo4jUrl);
                         }
                         finally
                         {

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -1,4 +1,7 @@
-﻿namespace Strazh.Analysis
+﻿using System;
+using System.IO;
+
+namespace Strazh.Analysis
 {
     public class AnalyzerConfig
     {
@@ -35,13 +38,14 @@
         public string Solution { get; }
         public string[] Projects { get; }
         public bool IsDelete { get; }
+        public string? CacheDirectory { get; }
 
         public bool IsSolutionBased => !string.IsNullOrEmpty(Solution);
 
         public bool IsValid => (!string.IsNullOrEmpty(Solution) && Projects.Length == 0)
             || (string.IsNullOrEmpty(Solution) && Projects.Length > 0);
 
-        public AnalyzerConfig(string credentials, string tier, string delete, string solution, string[] projects)
+        public AnalyzerConfig(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
         {
             solution = solution == "none" ? "" : solution;
             Credentials = new CredentialsConfig(credentials);
@@ -49,6 +53,9 @@
             IsDelete = delete != "false";
             Solution = solution;
             Projects = projects ?? new string[] { };
+            CacheDirectory = string.IsNullOrEmpty(cacheDirectory)
+                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "strazh", "cache")
+                : cacheDirectory;
         }
 
         private Tiers MapTier(string mode)

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -41,7 +41,8 @@ namespace Strazh.Analysis
             string[] Projects,
             string? CacheDirectory = null,
             bool NoCache = false,
-            string? BuildLogDirectory = null
+            string? BuildLogDirectory = null,
+            string? Neo4jUrl = null
         );
 
         public CredentialsConfig Credentials { get; }
@@ -52,6 +53,7 @@ namespace Strazh.Analysis
         public string? CacheDirectory { get; }
         public bool NoCache { get; }
         public string? BuildLogDirectory { get; }
+        public string Neo4jUrl { get; }
 
         public bool IsSolutionBased => !string.IsNullOrEmpty(Solution);
 
@@ -74,6 +76,7 @@ namespace Strazh.Analysis
                 ? Path.Combine(strazhDataDir, "logs")
                 : options.BuildLogDirectory;
             NoCache = options.NoCache;
+            Neo4jUrl = string.IsNullOrEmpty(options.Neo4jUrl) ? "neo4j://localhost:7687" : options.Neo4jUrl;
         }
 
         private Tiers MapTier(string mode)

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -68,7 +68,20 @@ namespace Strazh.Analysis
             IsDelete = options.Delete != "false";
             Solution = solution;
             Projects = options.Projects ?? new string[] { };
-            var strazhDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "strazh");
+            // SpecialFolder.ApplicationData returns empty string on Linux when $HOME is unset
+            // (e.g. inside certain Docker images). Fall back through UserProfile and $HOME to
+            // the system temp directory so the cache path is always absolute and usable.
+            var appData = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+            if (string.IsNullOrEmpty(appData))
+            {
+                var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+                if (string.IsNullOrEmpty(home))
+                {
+                    home = Environment.GetEnvironmentVariable("HOME") ?? Path.GetTempPath();
+                }
+                appData = Path.Combine(home, ".config");
+            }
+            var strazhDataDir = Path.Combine(appData, "strazh");
             CacheDirectory = string.IsNullOrEmpty(options.CacheDirectory)
                 ? Path.Combine(strazhDataDir, "cache")
                 : options.CacheDirectory;

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -33,29 +33,47 @@ namespace Strazh.Analysis
             Code = 2
         }
 
+        public record Options(
+            string Credentials,
+            string Tier,
+            string Delete,
+            string Solution,
+            string[] Projects,
+            string? CacheDirectory = null,
+            bool NoCache = false,
+            string? BuildLogDirectory = null
+        );
+
         public CredentialsConfig Credentials { get; }
         public Tiers Tier { get; }
         public string Solution { get; }
         public string[] Projects { get; }
         public bool IsDelete { get; }
         public string? CacheDirectory { get; }
+        public bool NoCache { get; }
+        public string? BuildLogDirectory { get; }
 
         public bool IsSolutionBased => !string.IsNullOrEmpty(Solution);
 
         public bool IsValid => (!string.IsNullOrEmpty(Solution) && Projects.Length == 0)
             || (string.IsNullOrEmpty(Solution) && Projects.Length > 0);
 
-        public AnalyzerConfig(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
+        public AnalyzerConfig(Options options)
         {
-            solution = solution == "none" ? "" : solution;
-            Credentials = new CredentialsConfig(credentials);
-            Tier = MapTier(tier);
-            IsDelete = delete != "false";
+            var solution = options.Solution == "none" ? "" : options.Solution;
+            Credentials = new CredentialsConfig(options.Credentials);
+            Tier = MapTier(options.Tier);
+            IsDelete = options.Delete != "false";
             Solution = solution;
-            Projects = projects ?? new string[] { };
-            CacheDirectory = string.IsNullOrEmpty(cacheDirectory)
-                ? Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "strazh", "cache")
-                : cacheDirectory;
+            Projects = options.Projects ?? new string[] { };
+            var strazhDataDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "strazh");
+            CacheDirectory = string.IsNullOrEmpty(options.CacheDirectory)
+                ? Path.Combine(strazhDataDir, "cache")
+                : options.CacheDirectory;
+            BuildLogDirectory = string.IsNullOrEmpty(options.BuildLogDirectory)
+                ? Path.Combine(strazhDataDir, "logs")
+                : options.BuildLogDirectory;
+            NoCache = options.NoCache;
         }
 
         private Tiers MapTier(string mode)

--- a/Strazh/Analysis/AnalyzerConfig.cs
+++ b/Strazh/Analysis/AnalyzerConfig.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 
 namespace Strazh.Analysis
 {
@@ -66,8 +67,10 @@ namespace Strazh.Analysis
             Credentials = new CredentialsConfig(options.Credentials);
             Tier = MapTier(options.Tier);
             IsDelete = options.Delete != "false";
-            Solution = solution;
-            Projects = options.Projects ?? new string[] { };
+            Solution = string.IsNullOrEmpty(solution) ? solution : Path.GetFullPath(solution);
+            Projects = (options.Projects ?? Array.Empty<string>())
+                .Select(Path.GetFullPath)
+                .ToArray();
             // SpecialFolder.ApplicationData returns empty string on Linux when $HOME is unset
             // (e.g. inside certain Docker images). Fall back through UserProfile and $HOME to
             // the system temp directory so the cache path is always absolute and usable.

--- a/Strazh/Analysis/BuildStageLabel.cs
+++ b/Strazh/Analysis/BuildStageLabel.cs
@@ -1,0 +1,23 @@
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// Identifies the build stage shown in the progress UI during an
+    /// <see cref="IAnalysisProgress.OnBuildStarted"/> notification.
+    /// </summary>
+    public enum BuildStageLabel
+    {
+        /// <summary>
+        /// The dependency-discovery pass. Runs full MSBuild invocations to populate the
+        /// binlog cache and <c>.deps</c> sidecars. This is the pass that actually compiles
+        /// the project; subsequent runs replay the cached binlog instead of rebuilding.
+        /// </summary>
+        Building,
+
+        /// <summary>
+        /// The knowledge-graph pass. Replays the binlog cache (or runs a fresh MSBuild build
+        /// if the cache is stale) then loads the results into the Roslyn workspace for triple
+        /// extraction, grouping, and insertion into the graph database.
+        /// </summary>
+        Graphing,
+    }
+}

--- a/Strazh/Analysis/BuildStageLabel.cs
+++ b/Strazh/Analysis/BuildStageLabel.cs
@@ -14,10 +14,10 @@ namespace Strazh.Analysis
         Building,
 
         /// <summary>
-        /// The knowledge-graph pass. Replays the binlog cache (or runs a fresh MSBuild build
-        /// if the cache is stale) then loads the results into the Roslyn workspace for triple
-        /// extraction, grouping, and insertion into the graph database.
+        /// The post-build pass. Replays the binlog cache (or runs a fresh MSBuild build if the
+        /// cache is stale) then loads the results into the Roslyn workspace for triple extraction,
+        /// grouping, and insertion into the graph database.
         /// </summary>
-        Graphing,
+        PostBuild,
     }
 }

--- a/Strazh/Analysis/CompositeAnalysisProgress.cs
+++ b/Strazh/Analysis/CompositeAnalysisProgress.cs
@@ -35,7 +35,7 @@ namespace Strazh.Analysis
             return current();
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
         {
             foreach (var impl in _implementations)
             {

--- a/Strazh/Analysis/CompositeAnalysisProgress.cs
+++ b/Strazh/Analysis/CompositeAnalysisProgress.cs
@@ -35,11 +35,11 @@ namespace Strazh.Analysis
             return current();
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
         {
             foreach (var impl in _implementations)
             {
-                impl.OnBuildStarted(projectFilePath, projectName, isCacheHit);
+                impl.OnBuildStarted(projectFilePath, projectName, isCacheHit, buildLabel);
             }
         }
 

--- a/Strazh/Analysis/CompositeAnalysisProgress.cs
+++ b/Strazh/Analysis/CompositeAnalysisProgress.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Domain;
+
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// Fans out every <see cref="IAnalysisProgress"/> notification to any number of
+    /// implementations. For <see cref="WrapAsync"/>, implementations are nested in the
+    /// order supplied so that the first implementation is the outermost wrapper — any UI
+    /// framework context it establishes (e.g. Spectre.Console's live display) is active
+    /// when subsequent implementations' <c>WrapAsync</c> calls run.
+    /// </summary>
+    public sealed class CompositeAnalysisProgress : IAnalysisProgress
+    {
+        private readonly IAnalysisProgress[] _implementations;
+
+        public CompositeAnalysisProgress(params IAnalysisProgress[] implementations)
+        {
+            _implementations = implementations;
+        }
+
+        public Task WrapAsync(int totalProjects, Func<Task> action)
+        {
+            // Build the nested chain from right to left so the first implementation
+            // is the outermost wrapper.
+            var current = action;
+            for (var i = _implementations.Length - 1; i >= 0; i--)
+            {
+                var impl = _implementations[i];
+                var next = current;
+                current = () => impl.WrapAsync(totalProjects, next);
+            }
+            return current();
+        }
+
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnBuildStarted(projectFilePath, projectName, isCacheHit);
+            }
+        }
+
+        public void OnBuildCompleted(string projectFilePath)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnBuildCompleted(projectFilePath);
+            }
+        }
+
+        public void OnStageChanged(string projectFilePath, string projectName, string stage)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnStageChanged(projectFilePath, projectName, stage);
+            }
+        }
+
+        public void OnProjectCompleted(string projectFilePath, int tripleCount)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnProjectCompleted(projectFilePath, tripleCount);
+            }
+        }
+
+        public void OnProjectSkipped(string projectFilePath, string filename, string reason)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnProjectSkipped(projectFilePath, filename, reason);
+            }
+        }
+
+        public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples)
+        {
+            foreach (var impl in _implementations)
+            {
+                impl.OnGroupingError(projectName, triples);
+            }
+        }
+    }
+}

--- a/Strazh/Analysis/CompositeAnalysisProgress.cs
+++ b/Strazh/Analysis/CompositeAnalysisProgress.cs
@@ -35,7 +35,7 @@ namespace Strazh.Analysis
             return current();
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel)
         {
             foreach (var impl in _implementations)
             {

--- a/Strazh/Analysis/Extractor.cs
+++ b/Strazh/Analysis/Extractor.cs
@@ -157,7 +157,7 @@ namespace Strazh.Analysis
                 foreach (var baseTypeSyntax in declaration.BaseList.Types)
                 {
                     var parentNode = sem.GetTypeInfo(baseTypeSyntax.Type).CreateTypeNode();
-                    if (node is ClassNode classNode)
+                    if (node is ClassNode classNode && parentNode != null)
                     {
                         triples.Add(new TripleOfType(classNode, parentNode));
                     }

--- a/Strazh/Analysis/FileAnalysisProgress.cs
+++ b/Strazh/Analysis/FileAnalysisProgress.cs
@@ -54,11 +54,11 @@ namespace Strazh.Analysis
             }
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel)
         {
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;
-            Write("BUILD_STARTED", $"cache={isCacheHit.ToString().ToLowerInvariant()} label={Q(buildLabel)} name={Q(projectName)} path={Q(projectFilePath)}");
+            Write("BUILD_STARTED", $"cache={isCacheHit.ToString().ToLowerInvariant()} label={Q(buildLabel.ToString())} name={Q(projectName)} path={Q(projectFilePath)}");
         }
 
         public void OnBuildCompleted(string projectFilePath)

--- a/Strazh/Analysis/FileAnalysisProgress.cs
+++ b/Strazh/Analysis/FileAnalysisProgress.cs
@@ -54,7 +54,7 @@ namespace Strazh.Analysis
             }
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
         {
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;

--- a/Strazh/Analysis/FileAnalysisProgress.cs
+++ b/Strazh/Analysis/FileAnalysisProgress.cs
@@ -54,11 +54,11 @@ namespace Strazh.Analysis
             }
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
         {
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;
-            Write("BUILD_STARTED", $"cache={isCacheHit.ToString().ToLowerInvariant()} name={Q(projectName)} path={Q(projectFilePath)}");
+            Write("BUILD_STARTED", $"cache={isCacheHit.ToString().ToLowerInvariant()} label={Q(buildLabel)} name={Q(projectName)} path={Q(projectFilePath)}");
         }
 
         public void OnBuildCompleted(string projectFilePath)

--- a/Strazh/Analysis/FileAnalysisProgress.cs
+++ b/Strazh/Analysis/FileAnalysisProgress.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Strazh.Domain;
+
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// Implements <see cref="IAnalysisProgress"/> by writing a structured, machine-readable
+    /// log file that captures the exact timing and outcome of every step in the analysis
+    /// pipeline. The file is useful for post-run diagnosis of failures that are not obvious
+    /// from the interactive console output (e.g. whether a project was a cache hit, whether
+    /// the binlog was read successfully, what order projects completed in).
+    ///
+    /// Log format — one entry per line:
+    /// <code>
+    ///   {ISO-8601-UTC} {EVENT} {key=value ...}
+    /// </code>
+    /// String values are double-quoted; numbers and booleans are unquoted. All methods are
+    /// safe to call concurrently from multiple tasks.
+    /// </summary>
+    public sealed class FileAnalysisProgress : IAnalysisProgress, IDisposable
+    {
+        private readonly StreamWriter _writer;
+        private readonly object _lock = new();
+        private readonly ConcurrentDictionary<string, DateTime> _startTimes = new(StringComparer.OrdinalIgnoreCase);
+        private readonly DateTime _runStart = DateTime.UtcNow;
+        private int _total;
+
+        public FileAnalysisProgress(string logFilePath)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(logFilePath)!);
+            _writer = new StreamWriter(logFilePath, append: false, System.Text.Encoding.UTF8)
+            {
+                AutoFlush = true
+            };
+        }
+
+        public async Task WrapAsync(int totalProjects, Func<Task> action)
+        {
+            _total = totalProjects;
+            Write("RUN_STARTED", $"total={totalProjects}");
+            try
+            {
+                await action();
+            }
+            finally
+            {
+                var elapsed = DateTime.UtcNow - _runStart;
+                Write("RUN_COMPLETE", $"elapsed={FormatElapsed(elapsed)} total={_total}");
+            }
+        }
+
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        {
+            var now = DateTime.UtcNow;
+            _startTimes[projectFilePath] = now;
+            Write("BUILD_STARTED", $"cache={isCacheHit.ToString().ToLowerInvariant()} name={Q(projectName)} path={Q(projectFilePath)}");
+        }
+
+        public void OnBuildCompleted(string projectFilePath)
+        {
+            var elapsed = DateTime.UtcNow - GetStart(projectFilePath);
+            Write("BUILD_COMPLETE", $"elapsed={FormatElapsed(elapsed)} path={Q(projectFilePath)}");
+        }
+
+        public void OnStageChanged(string projectFilePath, string projectName, string stage)
+        {
+            Write("STAGE", $"stage={Q(stage)} name={Q(projectName)} path={Q(projectFilePath)}");
+        }
+
+        public void OnProjectCompleted(string projectFilePath, int tripleCount)
+        {
+            var elapsed = DateTime.UtcNow - GetStart(projectFilePath);
+            Write("PROJECT_COMPLETE", $"triples={tripleCount} elapsed={FormatElapsed(elapsed)} path={Q(projectFilePath)}");
+        }
+
+        public void OnProjectSkipped(string projectFilePath, string filename, string reason)
+        {
+            var elapsed = DateTime.UtcNow - GetStart(projectFilePath);
+            Write("PROJECT_SKIPPED", $"file={Q(filename)} reason={Q(reason)} elapsed={FormatElapsed(elapsed)} path={Q(projectFilePath)}");
+        }
+
+        public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples)
+        {
+            Write("GROUPING_ERROR", $"project={Q(projectName)} triples={triples.Count}");
+        }
+
+        public void Dispose() => _writer.Dispose();
+
+        // --- helpers ---
+
+        private void Write(string eventName, string fields)
+        {
+            var line = $"{DateTime.UtcNow:yyyy-MM-ddTHH:mm:ss.fffZ} {eventName} {fields}";
+            lock (_lock)
+            {
+                _writer.WriteLine(line);
+            }
+        }
+
+        private DateTime GetStart(string projectFilePath)
+            => _startTimes.TryGetValue(projectFilePath, out var t) ? t : _runStart;
+
+        // Surrounds a string value with double quotes, escaping any embedded double quotes.
+        private static string Q(string value) => $"\"{value.Replace("\"", "\\\"")}\"";
+
+        private static string FormatElapsed(TimeSpan elapsed)
+            => $"{elapsed.TotalSeconds:F3}s";
+    }
+}

--- a/Strazh/Analysis/GitHelper.cs
+++ b/Strazh/Analysis/GitHelper.cs
@@ -1,13 +1,22 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace Strazh.Analysis
 {
+    /// <summary>
+    /// One entry in a repository's <c>.gitmodules</c> file: the path where the submodule
+    /// is mounted inside the host repo, and the <c>owner/repo</c> name of the repository
+    /// the submodule references (with relative URLs resolved against the host's origin).
+    /// </summary>
+    public sealed record Submodule(string MountPath, string RepositoryName);
+
     public static class GitHelper
     {
         /// <summary>
         /// Walks up from <paramref name="startPath"/> until a directory containing a
-        /// <c>.git</c> subdirectory is found, then returns that directory's full path.
+        /// <c>.git</c> entry (a directory for a regular repo, a file for a submodule
+        /// checkout) is found, then returns that directory's full path.
         /// Returns <c>null</c> when the path is not inside a git repository.
         /// </summary>
         public static string? FindGitRoot(string startPath)
@@ -15,7 +24,8 @@ namespace Strazh.Analysis
             var dir = Directory.Exists(startPath) ? startPath : Path.GetDirectoryName(startPath);
             while (dir != null)
             {
-                if (Directory.Exists(Path.Combine(dir, ".git")))
+                var gitPath = Path.Combine(dir, ".git");
+                if (Directory.Exists(gitPath) || File.Exists(gitPath))
                 {
                     return dir;
                 }
@@ -26,9 +36,9 @@ namespace Strazh.Analysis
 
         /// <summary>
         /// Returns the repository name in <c>owner/repo</c> form by reading the URL of the
-        /// <c>origin</c> remote from the <c>.git/config</c> nearest to
-        /// <paramref name="startPath"/>. Returns <c>null</c> when the git root or the
-        /// remote URL cannot be determined.
+        /// <c>origin</c> remote from the git config nearest to <paramref name="startPath"/>.
+        /// Follows <c>.git</c> files used by submodule checkouts to their real git directory.
+        /// Returns <c>null</c> when the git root or the remote URL cannot be determined.
         /// </summary>
         public static string? GetRepositoryName(string startPath)
         {
@@ -37,16 +47,96 @@ namespace Strazh.Analysis
             {
                 return null;
             }
+            var url = ReadOriginUrl(gitRoot);
+            return url == null ? null : ParseRepoName(url);
+        }
 
-            var configPath = Path.Combine(gitRoot, ".git", "config");
+        /// <summary>
+        /// Reads <c>.gitmodules</c> at the git root nearest to <paramref name="startPath"/>
+        /// and returns one entry per declared submodule. Relative URLs (<c>./</c> /
+        /// <c>../</c>) are resolved against the host's <c>origin</c> URL using git's own
+        /// rules; absolute URLs are parsed directly. Entries whose URL cannot be resolved
+        /// to an <c>owner/repo</c> form are skipped. Returns an empty list when there is
+        /// no <c>.gitmodules</c> file.
+        /// </summary>
+        public static IReadOnlyList<Submodule> GetSubmodules(string startPath)
+        {
+            var gitRoot = FindGitRoot(startPath);
+            if (gitRoot == null)
+            {
+                return [];
+            }
+
+            var entries = GitModulesParser.ParseFile(Path.Combine(gitRoot, ".gitmodules"));
+            if (entries.Count == 0)
+            {
+                return [];
+            }
+
+            var parentUrl = ReadOriginUrl(gitRoot);
+            var results = new List<Submodule>();
+            foreach (var entry in entries)
+            {
+                var resolved = ResolveSubmoduleUrl(entry.Url, parentUrl);
+                if (resolved == null)
+                {
+                    continue;
+                }
+                var repoName = ParseRepoName(resolved);
+                if (repoName == null)
+                {
+                    continue;
+                }
+                results.Add(new Submodule(entry.Path, repoName));
+            }
+            return results;
+        }
+
+        // Resolves the directory holding the real git metadata (config, HEAD, etc.) for the
+        // repository rooted at gitRoot. For a regular repo this is <gitRoot>/.git. For a
+        // submodule checkout, .git is a file containing "gitdir: <relative-path>" pointing
+        // into the parent's .git/modules/<name>/ directory.
+        private static string? ResolveGitDir(string gitRoot)
+        {
+            var gitPath = Path.Combine(gitRoot, ".git");
+            if (Directory.Exists(gitPath))
+            {
+                return gitPath;
+            }
+            if (!File.Exists(gitPath))
+            {
+                return null;
+            }
+
+            var content = File.ReadAllText(gitPath).Trim();
+            const string prefix = "gitdir:";
+            if (!content.StartsWith(prefix, StringComparison.Ordinal))
+            {
+                return null;
+            }
+            var target = content[prefix.Length..].Trim();
+            if (!Path.IsPathRooted(target))
+            {
+                target = Path.GetFullPath(Path.Combine(gitRoot, target));
+            }
+            return Directory.Exists(target) ? target : null;
+        }
+
+        private static string? ReadOriginUrl(string gitRoot)
+        {
+            var gitDir = ResolveGitDir(gitRoot);
+            if (gitDir == null)
+            {
+                return null;
+            }
+            var configPath = Path.Combine(gitDir, "config");
             if (!File.Exists(configPath))
             {
                 return null;
             }
 
-            var lines = File.ReadAllLines(configPath);
             var inOrigin = false;
-            foreach (var line in lines)
+            foreach (var line in File.ReadAllLines(configPath))
             {
                 var trimmed = line.Trim();
                 if (trimmed == "[remote \"origin\"]")
@@ -58,43 +148,125 @@ namespace Strazh.Analysis
                 {
                     break;
                 }
-                if (inOrigin && trimmed.StartsWith("url = ", StringComparison.Ordinal))
+                if (!inOrigin)
                 {
-                    var url = trimmed["url = ".Length..].Trim();
-                    return ParseRepoName(url);
+                    continue;
+                }
+                var eqIdx = trimmed.IndexOf('=');
+                if (eqIdx < 0)
+                {
+                    continue;
+                }
+                if (trimmed[..eqIdx].Trim() == "url")
+                {
+                    return trimmed[(eqIdx + 1)..].Trim();
                 }
             }
             return null;
         }
 
+        // Resolves a relative submodule URL (./foo, ../foo, ../../foo, …) against the
+        // host repo's origin URL using System.Uri.
+        //
+        // Trailing-slash trick: appending "/" to the parent URL makes Uri treat the
+        // parent's last segment (the repo name) as a directory, so ".." goes up from
+        // the repo level — matching git's submodule URL resolution rule, where the
+        // repo-name segment is itself stripped by the first "..".
+        //
+        // scp-style SSH URLs (git@host:path) are not URIs proper; Uri doesn't grok them.
+        // We round-trip them through the equivalent ssh:// form just for resolution.
+        private static string? ResolveSubmoduleUrl(string submoduleUrl, string? parentUrl)
+        {
+            if (Uri.TryCreate(submoduleUrl, UriKind.Absolute, out _) || IsScpLikeSsh(submoduleUrl))
+            {
+                return submoduleUrl;
+            }
+            if (parentUrl == null)
+            {
+                return null;
+            }
+
+            var parentAsUri = AsAbsoluteUri(parentUrl);
+            if (parentAsUri == null)
+            {
+                return null;
+            }
+
+            var baseWithTrailingSlash = new Uri(parentAsUri.AbsoluteUri + "/");
+            if (!Uri.TryCreate(baseWithTrailingSlash, submoduleUrl, out var resolved))
+            {
+                return null;
+            }
+
+            return IsScpLikeSsh(parentUrl) ? ToScpForm(resolved) : resolved.AbsoluteUri;
+        }
+
+        // Detects scp-like SSH syntax: user@host:path with no "://" — git@github.com:Org/Repo.git.
+        // Distinguishing rule: a ':' appears before any '/', and the string has no scheme delimiter.
+        private static bool IsScpLikeSsh(string url)
+        {
+            if (url.Contains("://", StringComparison.Ordinal))
+            {
+                return false;
+            }
+            var colon = url.IndexOf(':');
+            if (colon < 0)
+            {
+                return false;
+            }
+            var firstSlash = url.IndexOf('/');
+            return firstSlash < 0 || firstSlash > colon;
+        }
+
+        private static Uri? AsAbsoluteUri(string url)
+        {
+            if (IsScpLikeSsh(url))
+            {
+                var colon = url.IndexOf(':');
+                var hostPart = url[..colon];
+                var path = url[(colon + 1)..];
+                return Uri.TryCreate($"ssh://{hostPart}/{path}", UriKind.Absolute, out var u) ? u : null;
+            }
+            return Uri.TryCreate(url, UriKind.Absolute, out var abs) ? abs : null;
+        }
+
+        // Renders an ssh:// Uri back into scp-like form: ssh://git@github.com/Org/Repo.git
+        // → git@github.com:Org/Repo.git.
+        private static string ToScpForm(Uri sshUri)
+        {
+            var userInfo = string.IsNullOrEmpty(sshUri.UserInfo) ? "" : sshUri.UserInfo + "@";
+            var path = sshUri.AbsolutePath.TrimStart('/');
+            return $"{userInfo}{sshUri.Host}:{path}";
+        }
+
+        // Extracts owner/repo from a git remote URL. Uses System.Uri for HTTP(S)/SSH URIs;
+        // scp-like SSH is handled by splitting on the ':' separator. The trailing ".git"
+        // suffix is stripped if present.
         private static string? ParseRepoName(string url)
         {
             try
             {
-                // SSH format: git@github.com:owner/repo.git
-                if (url.Contains('@') && !url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                string path;
+                if (IsScpLikeSsh(url))
                 {
-                    var colonIdx = url.IndexOf(':');
-                    if (colonIdx < 0)
+                    var colon = url.IndexOf(':');
+                    path = url[(colon + 1)..];
+                }
+                else
+                {
+                    if (!Uri.TryCreate(url, UriKind.Absolute, out var uri))
                     {
                         return null;
                     }
-                    var path = url[(colonIdx + 1)..].TrimEnd('/');
-                    if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
-                    {
-                        path = path[..^4];
-                    }
-                    return path;
+                    path = uri.AbsolutePath;
                 }
-
-                // HTTPS format: https://github.com/owner/repo.git
-                var uri = new Uri(url);
-                var httpPath = uri.AbsolutePath.TrimStart('/').TrimEnd('/');
-                if (httpPath.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                path = path.Trim('/');
+                const string gitSuffix = ".git";
+                if (path.EndsWith(gitSuffix, StringComparison.OrdinalIgnoreCase))
                 {
-                    httpPath = httpPath[..^4];
+                    path = path[..^gitSuffix.Length];
                 }
-                return httpPath;
+                return path.Length == 0 ? null : path;
             }
             catch
             {

--- a/Strazh/Analysis/GitHelper.cs
+++ b/Strazh/Analysis/GitHelper.cs
@@ -1,0 +1,105 @@
+using System;
+using System.IO;
+
+namespace Strazh.Analysis
+{
+    public static class GitHelper
+    {
+        /// <summary>
+        /// Walks up from <paramref name="startPath"/> until a directory containing a
+        /// <c>.git</c> subdirectory is found, then returns that directory's full path.
+        /// Returns <c>null</c> when the path is not inside a git repository.
+        /// </summary>
+        public static string? FindGitRoot(string startPath)
+        {
+            var dir = Directory.Exists(startPath) ? startPath : Path.GetDirectoryName(startPath);
+            while (dir != null)
+            {
+                if (Directory.Exists(Path.Combine(dir, ".git")))
+                {
+                    return dir;
+                }
+                dir = Directory.GetParent(dir)?.FullName;
+            }
+            return null;
+        }
+
+        /// <summary>
+        /// Returns the repository name in <c>owner/repo</c> form by reading the URL of the
+        /// <c>origin</c> remote from the <c>.git/config</c> nearest to
+        /// <paramref name="startPath"/>. Returns <c>null</c> when the git root or the
+        /// remote URL cannot be determined.
+        /// </summary>
+        public static string? GetRepositoryName(string startPath)
+        {
+            var gitRoot = FindGitRoot(startPath);
+            if (gitRoot == null)
+            {
+                return null;
+            }
+
+            var configPath = Path.Combine(gitRoot, ".git", "config");
+            if (!File.Exists(configPath))
+            {
+                return null;
+            }
+
+            var lines = File.ReadAllLines(configPath);
+            var inOrigin = false;
+            foreach (var line in lines)
+            {
+                var trimmed = line.Trim();
+                if (trimmed == "[remote \"origin\"]")
+                {
+                    inOrigin = true;
+                    continue;
+                }
+                if (inOrigin && trimmed.StartsWith('['))
+                {
+                    break;
+                }
+                if (inOrigin && trimmed.StartsWith("url = ", StringComparison.Ordinal))
+                {
+                    var url = trimmed["url = ".Length..].Trim();
+                    return ParseRepoName(url);
+                }
+            }
+            return null;
+        }
+
+        private static string? ParseRepoName(string url)
+        {
+            try
+            {
+                // SSH format: git@github.com:owner/repo.git
+                if (url.Contains('@') && !url.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+                {
+                    var colonIdx = url.IndexOf(':');
+                    if (colonIdx < 0)
+                    {
+                        return null;
+                    }
+                    var path = url[(colonIdx + 1)..].TrimEnd('/');
+                    if (path.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                    {
+                        path = path[..^4];
+                    }
+                    return path;
+                }
+
+                // HTTPS format: https://github.com/owner/repo.git
+                var uri = new Uri(url);
+                var httpPath = uri.AbsolutePath.TrimStart('/').TrimEnd('/');
+                if (httpPath.EndsWith(".git", StringComparison.OrdinalIgnoreCase))
+                {
+                    httpPath = httpPath[..^4];
+                }
+                return httpPath;
+            }
+            catch
+            {
+                return null;
+            }
+        }
+    }
+}

--- a/Strazh/Analysis/GitModulesParser.cs
+++ b/Strazh/Analysis/GitModulesParser.cs
@@ -1,0 +1,98 @@
+using System.Collections.Generic;
+using System.IO;
+
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// One submodule declaration parsed from a <c>.gitmodules</c> file. The URL is
+    /// returned verbatim — relative URLs (<c>./</c>, <c>../</c>) are NOT resolved here.
+    /// Resolution against the host repo's origin happens in <see cref="GitHelper"/>.
+    /// </summary>
+    public sealed record GitModuleEntry(string Name, string Path, string Url);
+
+    /// <summary>
+    /// Parser for git's <c>.gitmodules</c> file format. Recognizes
+    /// <c>[submodule "name"]</c> sections with <c>path</c> and <c>url</c> keys; other
+    /// sections, unknown keys, blank lines, and <c>#</c>/<c>;</c> comments are ignored.
+    /// Tolerant of <c>key=value</c> and <c>key = value</c> spacing.
+    /// </summary>
+    public sealed class GitModulesParser
+    {
+        private readonly List<GitModuleEntry> _results = new();
+        private string? _name;
+        private string? _path;
+        private string? _url;
+        private bool _inSubmodule;
+
+        public static IReadOnlyList<GitModuleEntry> Parse(string content)
+        {
+            var parser = new GitModulesParser();
+            parser.ParseLines(content);
+            return parser._results;
+        }
+
+        public static IReadOnlyList<GitModuleEntry> ParseFile(string path)
+            => File.Exists(path) ? Parse(File.ReadAllText(path)) : [];
+
+        private void ParseLines(string content)
+        {
+            foreach (var raw in content.Split('\n'))
+            {
+                var line = raw.Trim();
+                if (line.Length == 0 || line.StartsWith('#') || line.StartsWith(';'))
+                {
+                    continue;
+                }
+                if (line.StartsWith('['))
+                {
+                    Flush();
+                    const string head = "[submodule \"";
+                    const string tail = "\"]";
+                    if (line.StartsWith(head, System.StringComparison.Ordinal)
+                        && line.EndsWith(tail, System.StringComparison.Ordinal))
+                    {
+                        _inSubmodule = true;
+                        _name = line[head.Length..^tail.Length];
+                    }
+                    else
+                    {
+                        _inSubmodule = false;
+                    }
+                    continue;
+                }
+                if (!_inSubmodule)
+                {
+                    continue;
+                }
+                var eqIdx = line.IndexOf('=');
+                if (eqIdx < 0)
+                {
+                    continue;
+                }
+                var key = line[..eqIdx].Trim();
+                var value = line[(eqIdx + 1)..].Trim();
+                switch (key)
+                {
+                    case "path":
+                        _path = value;
+                        break;
+                    case "url":
+                        _url = value;
+                        break;
+                }
+            }
+            Flush();
+        }
+
+        private void Flush()
+        {
+            if (_inSubmodule && _name != null && _path != null && _url != null)
+            {
+                _results.Add(new GitModuleEntry(_name, _path, _url));
+            }
+            _name = null;
+            _path = null;
+            _url = null;
+        }
+    }
+}

--- a/Strazh/Analysis/IAnalysisProgress.cs
+++ b/Strazh/Analysis/IAnalysisProgress.cs
@@ -35,7 +35,12 @@ namespace Strazh.Analysis
         /// <c>true</c> when a cached binlog will be replayed;
         /// <c>false</c> when a full MSBuild invocation will run.
         /// </param>
-        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit);
+        /// <param name="buildLabel">
+        /// Short label for the build stage shown in the progress UI.
+        /// Use <c>"Scanning"</c> for the dependency-discovery pass and
+        /// <c>"Building"</c> (default) for the main build pass.
+        /// </param>
+        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building");
 
         /// <summary>
         /// Raised after the build or cache replay has finished and the result is

--- a/Strazh/Analysis/IAnalysisProgress.cs
+++ b/Strazh/Analysis/IAnalysisProgress.cs
@@ -37,10 +37,10 @@ namespace Strazh.Analysis
         /// </param>
         /// <param name="buildLabel">
         /// Short label for the build stage shown in the progress UI.
-        /// Use <c>"Scanning"</c> for the dependency-discovery pass and
-        /// <c>"Building"</c> (default) for the main build pass.
+        /// Use <c>"Building"</c> for the dependency-discovery pass and
+        /// <c>"Scanning"</c> (default) for the main build pass.
         /// </param>
-        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building");
+        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel);
 
         /// <summary>
         /// Raised after the build or cache replay has finished and the result is

--- a/Strazh/Analysis/IAnalysisProgress.cs
+++ b/Strazh/Analysis/IAnalysisProgress.cs
@@ -37,10 +37,10 @@ namespace Strazh.Analysis
         /// </param>
         /// <param name="buildLabel">
         /// Short label for the build stage shown in the progress UI.
-        /// Use <c>"Building"</c> for the dependency-discovery pass and
-        /// <c>"Scanning"</c> (default) for the main build pass.
+        /// Use <see cref="BuildStageLabel.Building"/> for the dependency-discovery pass and
+        /// <see cref="BuildStageLabel.Graphing"/> for the knowledge-graph pass.
         /// </param>
-        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel);
+        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel);
 
         /// <summary>
         /// Raised after the build or cache replay has finished and the result is

--- a/Strazh/Analysis/IAnalysisProgress.cs
+++ b/Strazh/Analysis/IAnalysisProgress.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Domain;
+
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// Receives progress notifications from the analysis pipeline.
+    /// Implementations are free to present events however they choose —
+    /// Spectre.Console spinners, plain Console.WriteLine, or a no-op for tests.
+    /// All methods except <see cref="WrapAsync"/> may be called concurrently
+    /// from multiple tasks.
+    /// </summary>
+    public interface IAnalysisProgress
+    {
+        /// <summary>
+        /// Wraps the entire analysis pipeline. The implementation is responsible
+        /// for calling <paramref name="action"/> exactly once.
+        /// This is the integration point for UI frameworks that require an outer
+        /// context (e.g. <c>AnsiConsole.Progress().StartAsync()</c>) to be
+        /// established before any progress notifications are raised.
+        /// </summary>
+        /// <param name="totalProjects">Total number of projects in this run.</param>
+        /// <param name="action">The pipeline body to execute.</param>
+        Task WrapAsync(int totalProjects, Func<Task> action);
+
+        /// <summary>
+        /// Raised immediately before the MSBuild design-time build (or binlog
+        /// cache replay) begins for the specified project.
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path to the .csproj file.</param>
+        /// <param name="projectName">Display name (filename without extension).</param>
+        /// <param name="isCacheHit">
+        /// <c>true</c> when a cached binlog will be replayed;
+        /// <c>false</c> when a full MSBuild invocation will run.
+        /// </param>
+        void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit);
+
+        /// <summary>
+        /// Raised after the build or cache replay has finished and the result is
+        /// about to be loaded into the Roslyn workspace.
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path to the .csproj file.</param>
+        void OnBuildCompleted(string projectFilePath);
+
+        /// <summary>
+        /// Raised each time the active processing stage changes for a project.
+        /// Expected values for <paramref name="stage"/> are <c>"Analyzing"</c>,
+        /// <c>"Grouping"</c>, and <c>"Inserting"</c>, but implementations must
+        /// tolerate arbitrary strings.
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path to the .csproj file.</param>
+        /// <param name="projectName">Display name (filename without extension).</param>
+        /// <param name="stage">Short human-readable label for the current stage.</param>
+        void OnStageChanged(string projectFilePath, string projectName, string stage);
+
+        /// <summary>
+        /// Raised after a project has been fully analyzed and all its triples
+        /// inserted into the database.
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path to the .csproj file.</param>
+        /// <param name="tripleCount">Number of triples inserted for this project.</param>
+        void OnProjectCompleted(string projectFilePath, int tripleCount);
+
+        /// <summary>
+        /// Raised when a project cannot be loaded into the Roslyn workspace because
+        /// its type is not supported (e.g. F# or native projects).
+        /// </summary>
+        /// <param name="projectFilePath">Absolute path to the project file.</param>
+        /// <param name="filename">Filename of the skipped project (e.g. MyLib.fsproj).</param>
+        /// <param name="reason">Human-readable explanation of why it was skipped.</param>
+        void OnProjectSkipped(string projectFilePath, string filename, string reason);
+
+        /// <summary>
+        /// Raised when triple deduplication (GroupBy) throws an exception.
+        /// The implementation should surface the triple list for diagnosis.
+        /// The pipeline will rethrow the exception after this method returns.
+        /// </summary>
+        /// <param name="projectName">Display name of the project whose grouping failed.</param>
+        /// <param name="triples">Raw (ungrouped) triples at the time of failure.</param>
+        void OnGroupingError(string projectName, IReadOnlyList<Triple> triples);
+    }
+}

--- a/Strazh/Analysis/IAnalysisProgress.cs
+++ b/Strazh/Analysis/IAnalysisProgress.cs
@@ -38,7 +38,7 @@ namespace Strazh.Analysis
         /// <param name="buildLabel">
         /// Short label for the build stage shown in the progress UI.
         /// Use <see cref="BuildStageLabel.Building"/> for the dependency-discovery pass and
-        /// <see cref="BuildStageLabel.Graphing"/> for the knowledge-graph pass.
+        /// <see cref="BuildStageLabel.PostBuild"/> for the knowledge-graph pass.
         /// </param>
         void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel);
 

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -25,6 +25,8 @@ namespace Strazh.Analysis
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string> _names =
             new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, string> _buildLabels =
+            new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, DateTime> _startTimes =
             new(StringComparer.OrdinalIgnoreCase);
         // Console writes (above the live area) must all come from the ticker thread to avoid
@@ -79,17 +81,27 @@ namespace Strazh.Analysis
                 });
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
         {
             _names[projectFilePath] = projectName;
+            _buildLabels[projectFilePath] = buildLabel;
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;
-            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : "Building", now, now);
+            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : buildLabel, now, now);
         }
 
         public void OnBuildCompleted(string projectFilePath)
         {
-            UpdateEntry(projectFilePath, "Loading");
+            // Scan-pass entries are pre-work: silently remove them from the active display
+            // rather than transitioning to "Loading" (they have no load or analysis step).
+            if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == "Scanning")
+            {
+                _active.TryRemove(projectFilePath, out _);
+            }
+            else
+            {
+                UpdateEntry(projectFilePath, "Loading");
+            }
         }
 
         public void OnStageChanged(string projectFilePath, string projectName, string stage)

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -188,15 +188,12 @@ namespace Strazh.Analysis
             return (completed, Math.Max(0, _total - completed));
         }
 
-        private (List<TaskEntry> entries, int paddingRows) GetSortedEntries()
+        private List<TaskEntry> GetSortedEntries()
         {
-            // Reserve 1 row for the summary line and 1 for breathing room.
-            var terminalHeight = AnsiConsole.Console.Profile.Height;
-            var maxContentRows = Math.Max(1, terminalHeight - 2);
-            var entries = _active.Values.OrderByDescending(e => e.LastChanged).Take(maxContentRows).ToList();
-            // Pad above the active entries so the summary line sits at the bottom of the terminal.
-            var paddingRows = Math.Max(0, maxContentRows - entries.Count);
-            return (entries, paddingRows);
+            // Cap at terminal height minus 2 rows (summary line + breathing room) so the
+            // live panel never overflows the terminal when many projects are in flight.
+            var maxContentRows = Math.Max(1, AnsiConsole.Console.Profile.Height - 2);
+            return _active.Values.OrderByDescending(e => e.LastChanged).Take(maxContentRows).ToList();
         }
 
         private static string FormatElapsed(TimeSpan elapsed)
@@ -219,14 +216,8 @@ namespace Strazh.Analysis
             public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
             {
                 var frame = _owner.GetSpinnerFrame();
-                var (entries, paddingRows) = _owner.GetSortedEntries();
+                var entries = _owner.GetSortedEntries();
                 var (completed, remaining) = _owner.GetCounts();
-
-                // Blank lines above the active-task block push it toward the bottom of the terminal.
-                for (var i = 0; i < paddingRows; i++)
-                {
-                    yield return Segment.LineBreak;
-                }
 
                 foreach (var entry in entries)
                 {

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -1,83 +1,50 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console;
-using Spectre.Console.Rendering;
 using Strazh.Domain;
 
 namespace Strazh.Analysis
 {
     /// <summary>
-    /// Implements <see cref="IAnalysisProgress"/> using Spectre.Console's Live display.
-    /// Active tasks are sorted by most-recently-updated so that any task receiving a stage
-    /// change floats to the top of the visible area, even when more projects are in flight
-    /// than the terminal can display at once.
+    /// Implements <see cref="IAnalysisProgress"/> using Spectre.Console's Progress display.
+    /// Each active project is a <see cref="ProgressTask"/>; completed and skipped lines are
+    /// written via <see cref="AnsiConsole.MarkupLine"/> which Progress's render hook intercepts,
+    /// clears the spinner area, writes the line to the terminal scrollback, and re-renders the
+    /// spinners below — leaving the terminal state clean.
     /// All methods except <see cref="WrapAsync"/> may be called concurrently from multiple tasks.
     /// </summary>
     public sealed class SpectreConsoleProgress : IAnalysisProgress
     {
-        private record struct TaskEntry(string Name, string Stage, DateTime StartTime, DateTime LastChanged);
-
-        private readonly ConcurrentDictionary<string, TaskEntry> _active =
-            new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string> _names =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, BuildStageLabel> _buildLabels =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, DateTime> _startTimes =
             new(StringComparer.OrdinalIgnoreCase);
-        // Console writes (above the live area) must all come from the ticker thread to avoid
-        // interleaving with ctx.Refresh(), which causes Spectre.Console to corrupt its cursor
-        // position and crash the ticker. Concurrent callers enqueue an action; the ticker
-        // drains the queue before each Refresh().
-        private readonly ConcurrentQueue<Action> _pendingWrites = new();
-        private LiveDisplayContext? _ctx;
-        private int _tick;
-        private int _total;
+        private readonly ConcurrentDictionary<string, ProgressTask> _tasks =
+            new(StringComparer.OrdinalIgnoreCase);
+        private volatile ProgressContext? _ctx;
         private int _completed;
+        private int _total;
 
-        // Dots spinner frames — same set used by Spectre.Console's built-in SpinnerColumn.
-        private static readonly string[] SpinnerFrames =
-            ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-
-        public Task WrapAsync(int totalProjects, Func<Task> action)
+        public async Task WrapAsync(int totalProjects, Func<Task> action)
         {
             _total = totalProjects;
-            return AnsiConsole.Live(new ActiveTasksRenderable(this))
+            await AnsiConsole.Progress()
                 .AutoClear(true)
-                .Overflow(VerticalOverflow.Ellipsis)
+                .HideCompleted(true)
+                .Columns(
+                    new SpinnerColumn(),
+                    new TaskDescriptionColumn { Alignment = Justify.Left }
+                )
                 .StartAsync(async ctx =>
                 {
                     _ctx = ctx;
-                    using var cts = new CancellationTokenSource();
-                    var ticker = Task.Run(async () =>
-                    {
-                        while (!cts.IsCancellationRequested)
-                        {
-                            await Task.Delay(80).ConfigureAwait(false);
-                            Interlocked.Increment(ref _tick);
-                            if (!cts.IsCancellationRequested)
-                            {
-                                while (_pendingWrites.TryDequeue(out var write))
-                                {
-                                    write();
-                                }
-                                ctx.Refresh();
-                            }
-                        }
-                    });
-                    try
-                    {
-                        await action();
-                    }
-                    finally
-                    {
-                        await cts.CancelAsync();
-                        await ticker;
-                    }
+                    await action();
+                    _ctx = null;
                 });
         }
 
@@ -85,46 +52,63 @@ namespace Strazh.Analysis
         {
             _names[projectFilePath] = projectName;
             _buildLabels[projectFilePath] = buildLabel;
-            var now = DateTime.UtcNow;
-            _startTimes[projectFilePath] = now;
-            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : buildLabel.ToString(), now, now);
+            _startTimes[projectFilePath] = DateTime.UtcNow;
+            if (_ctx is { } ctx)
+            {
+                var stage = isCacheHit ? "Cached" : buildLabel.ToString();
+                var task = ctx.AddTask($"{stage,-9} {Markup.Escape(projectName)}");
+                _tasks[projectFilePath] = task;
+            }
         }
 
         public void OnBuildCompleted(string projectFilePath)
         {
-            // Building-pass entries are pre-work: silently remove them from the active display
-            // rather than transitioning to "Loading" (they have no load or analysis step).
+            if (!_tasks.TryGetValue(projectFilePath, out var task))
+            {
+                return;
+            }
+            // Building-pass entries are pre-work: silently finish them rather than
+            // transitioning to "Loading" (they have no load or analysis step).
             if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == BuildStageLabel.Building)
             {
-                _active.TryRemove(projectFilePath, out _);
+                task.StopTask();
             }
             else
             {
-                UpdateEntry(projectFilePath, "Loading");
+                var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
+                task.Description = $"{"Loading",-9} {Markup.Escape(name)}";
             }
         }
 
         public void OnStageChanged(string projectFilePath, string projectName, string stage)
         {
-            UpdateEntry(projectFilePath, stage);
+            if (_tasks.TryGetValue(projectFilePath, out var task))
+            {
+                task.Description = $"{stage,-9} {Markup.Escape(projectName)}";
+            }
         }
 
         public void OnProjectCompleted(string projectFilePath, int tripleCount)
         {
             Interlocked.Increment(ref _completed);
-            _active.TryRemove(projectFilePath, out _);
+            if (_tasks.TryGetValue(projectFilePath, out var task))
+            {
+                task.StopTask();
+            }
             var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
             var elapsed = DateTime.UtcNow - (_startTimes.TryGetValue(projectFilePath, out var st) ? st : DateTime.UtcNow);
-            var markup =
+            AnsiConsole.MarkupLine(
                 $"[green]✓[/] [bold]{Markup.Escape(name)}[/]  " +
-                $"[dim]{FormatElapsed(elapsed)}[/]  {tripleCount} triples";
-            _pendingWrites.Enqueue(() => AnsiConsole.MarkupLine(markup));
+                $"[dim]{FormatElapsed(elapsed)}[/]  {tripleCount} triples");
         }
 
         public void OnProjectSkipped(string projectFilePath, string filename, string reason)
         {
             Interlocked.Increment(ref _completed);
-            _active.TryRemove(projectFilePath, out _);
+            if (_tasks.TryGetValue(projectFilePath, out var task))
+            {
+                task.StopTask();
+            }
             string label;
             if (reason.Contains("timed out"))
             {
@@ -142,102 +126,33 @@ namespace Strazh.Analysis
             {
                 label = "[yellow]Skipped[/]";
             }
-            var markup = $"{label} {Markup.Escape(filename)} ({Markup.Escape(reason)})";
-            _pendingWrites.Enqueue(() => AnsiConsole.MarkupLine(markup));
+            AnsiConsole.MarkupLine($"{label} {Markup.Escape(filename)} ({Markup.Escape(reason)})");
         }
 
         public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples)
         {
-            var capturedTriples = triples.ToList();
-            _pendingWrites.Enqueue(() =>
+            AnsiConsole.MarkupLine($"[red]Error[/] grouping triples for {Markup.Escape(projectName)}. Dumping detail:");
+            AnsiConsole.WriteLine("[");
+            var first = true;
+            foreach (var triple in triples)
             {
-                AnsiConsole.MarkupLine($"[red]Error[/] grouping triples for {Markup.Escape(projectName)}. Dumping detail:");
-                AnsiConsole.WriteLine("[");
-                var first = true;
-                foreach (var triple in capturedTriples)
+                if (!first)
                 {
-                    if (!first)
-                    {
-                        AnsiConsole.WriteLine(",");
-                    }
-                    AnsiConsole.Write(new Text($$"""{ "triple": {{ triple.ToInspection()}} }"""));
-                    first = false;
+                    AnsiConsole.WriteLine(",");
                 }
-                if (capturedTriples.Count > 0)
-                {
-                    AnsiConsole.WriteLine("");
-                }
-                AnsiConsole.WriteLine("]");
-            });
-        }
-
-        private void UpdateEntry(string projectFilePath, string stage)
-        {
-            if (_active.TryGetValue(projectFilePath, out var entry))
-            {
-                _active[projectFilePath] = entry with { Stage = stage, LastChanged = DateTime.UtcNow };
+                AnsiConsole.Write(new Text($$"""  { "triple": {{ triple.ToInspection()}} }"""));
+                first = false;
             }
-        }
-
-        private string GetSpinnerFrame()
-            => SpinnerFrames[Math.Abs(_tick) % SpinnerFrames.Length];
-
-        private (int completed, int remaining) GetCounts()
-        {
-            var completed = Volatile.Read(ref _completed);
-            return (completed, Math.Max(0, _total - completed));
-        }
-
-        private List<TaskEntry> GetSortedEntries()
-        {
-            // Cap at terminal height minus 2 rows (summary line + breathing room) so the
-            // live panel never overflows the terminal when many projects are in flight.
-            var maxContentRows = Math.Max(1, AnsiConsole.Console.Profile.Height - 2);
-            return _active.Values.OrderByDescending(e => e.LastChanged).Take(maxContentRows).ToList();
+            if (triples.Count > 0)
+            {
+                AnsiConsole.WriteLine("");
+            }
+            AnsiConsole.WriteLine("]");
         }
 
         private static string FormatElapsed(TimeSpan elapsed)
             => elapsed.TotalSeconds < 60
                 ? $"{elapsed.TotalSeconds:F1}s"
                 : $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
-
-        /// <summary>
-        /// Live-renderable that rebuilds on every <see cref="LiveDisplayContext.Refresh"/> call,
-        /// always placing the most recently updated task at the top.
-        /// </summary>
-        private sealed class ActiveTasksRenderable : IRenderable
-        {
-            private readonly SpectreConsoleProgress _owner;
-
-            public ActiveTasksRenderable(SpectreConsoleProgress owner) => _owner = owner;
-
-            public Measurement Measure(RenderOptions options, int maxWidth) => new(0, maxWidth);
-
-            public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
-            {
-                var frame = _owner.GetSpinnerFrame();
-                var entries = _owner.GetSortedEntries();
-                var (completed, remaining) = _owner.GetCounts();
-
-                foreach (var entry in entries)
-                {
-                    var elapsed = DateTime.UtcNow - entry.StartTime;
-                    var line = new Markup(
-                        $"[green]{frame}[/] {entry.Stage,-9} {Markup.Escape(entry.Name)}  [dim]{FormatElapsed(elapsed)}[/]");
-                    foreach (var seg in ((IRenderable)line).Render(options, maxWidth))
-                    {
-                        yield return seg;
-                    }
-                    yield return Segment.LineBreak;
-                }
-
-                var summary = new Markup($"[dim]{completed} done · {remaining} remaining[/]");
-                foreach (var seg in ((IRenderable)summary).Render(options, maxWidth))
-                {
-                    yield return seg;
-                }
-                yield return Segment.LineBreak;
-            }
-        }
     }
 }

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -27,6 +27,11 @@ namespace Strazh.Analysis
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, DateTime> _startTimes =
             new(StringComparer.OrdinalIgnoreCase);
+        // Console writes (above the live area) must all come from the ticker thread to avoid
+        // interleaving with ctx.Refresh(), which causes Spectre.Console to corrupt its cursor
+        // position and crash the ticker. Concurrent callers enqueue an action; the ticker
+        // drains the queue before each Refresh().
+        private readonly ConcurrentQueue<Action> _pendingWrites = new();
         private LiveDisplayContext? _ctx;
         private int _tick;
         private int _total;
@@ -54,6 +59,10 @@ namespace Strazh.Analysis
                             Interlocked.Increment(ref _tick);
                             if (!cts.IsCancellationRequested)
                             {
+                                while (_pendingWrites.TryDequeue(out var write))
+                                {
+                                    write();
+                                }
                                 ctx.Refresh();
                             }
                         }
@@ -76,7 +85,6 @@ namespace Strazh.Analysis
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;
             _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : "Building", now, now);
-            _ctx?.Refresh();
         }
 
         public void OnBuildCompleted(string projectFilePath)
@@ -95,39 +103,43 @@ namespace Strazh.Analysis
             _active.TryRemove(projectFilePath, out _);
             var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
             var elapsed = DateTime.UtcNow - (_startTimes.TryGetValue(projectFilePath, out var st) ? st : DateTime.UtcNow);
-            AnsiConsole.MarkupLine(
+            var markup =
                 $"[green]✓[/] [bold]{Markup.Escape(name)}[/]  " +
-                $"[dim]{FormatElapsed(elapsed)}[/]  {tripleCount} triples");
-            _ctx?.Refresh();
+                $"[dim]{FormatElapsed(elapsed)}[/]  {tripleCount} triples";
+            _pendingWrites.Enqueue(() => AnsiConsole.MarkupLine(markup));
         }
 
         public void OnProjectSkipped(string projectFilePath, string filename, string reason)
         {
             Interlocked.Increment(ref _completed);
             _active.TryRemove(projectFilePath, out _);
-            AnsiConsole.MarkupLine($"[yellow]Skipped[/] {Markup.Escape(filename)} ({Markup.Escape(reason)})");
-            _ctx?.Refresh();
+            var markup = $"[yellow]Skipped[/] {Markup.Escape(filename)} ({Markup.Escape(reason)})";
+            _pendingWrites.Enqueue(() => AnsiConsole.MarkupLine(markup));
         }
 
         public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples)
         {
-            AnsiConsole.MarkupLine($"[red]Error[/] grouping triples for {Markup.Escape(projectName)}. Dumping detail:");
-            AnsiConsole.WriteLine("[");
-            var first = true;
-            foreach (var triple in triples)
+            var capturedTriples = triples.ToList();
+            _pendingWrites.Enqueue(() =>
             {
-                if (!first)
+                AnsiConsole.MarkupLine($"[red]Error[/] grouping triples for {Markup.Escape(projectName)}. Dumping detail:");
+                AnsiConsole.WriteLine("[");
+                var first = true;
+                foreach (var triple in capturedTriples)
                 {
-                    AnsiConsole.WriteLine(",");
+                    if (!first)
+                    {
+                        AnsiConsole.WriteLine(",");
+                    }
+                    AnsiConsole.Write(new Text($$"""{ "triple": {{ triple.ToInspection()}} }"""));
+                    first = false;
                 }
-                AnsiConsole.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
-                first = false;
-            }
-            if (triples.Count > 0)
-            {
-                AnsiConsole.WriteLine("");
-            }
-            AnsiConsole.WriteLine("]");
+                if (capturedTriples.Count > 0)
+                {
+                    AnsiConsole.WriteLine("");
+                }
+                AnsiConsole.WriteLine("]");
+            });
         }
 
         private void UpdateEntry(string projectFilePath, string stage)
@@ -135,7 +147,6 @@ namespace Strazh.Analysis
             if (_active.TryGetValue(projectFilePath, out var entry))
             {
                 _active[projectFilePath] = entry with { Stage = stage, LastChanged = DateTime.UtcNow };
-                _ctx?.Refresh();
             }
         }
 

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -48,7 +48,7 @@ namespace Strazh.Analysis
                 .Columns(new PanelColumn(this))
                 .StartAsync(async ctx =>
                 {
-                    ctx.AddTask(" ");
+                    ctx.AddTask(".");
                     using var cts = new CancellationTokenSource();
                     var ticker = Task.Run(async () =>
                     {

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -48,7 +48,7 @@ namespace Strazh.Analysis
                 .Columns(new PanelColumn(this))
                 .StartAsync(async ctx =>
                 {
-                    ctx.AddTask(string.Empty);
+                    ctx.AddTask(" ");
                     using var cts = new CancellationTokenSource();
                     var ticker = Task.Run(async () =>
                     {

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -25,7 +25,7 @@ namespace Strazh.Analysis
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string> _names =
             new(StringComparer.OrdinalIgnoreCase);
-        private readonly ConcurrentDictionary<string, string> _buildLabels =
+        private readonly ConcurrentDictionary<string, BuildStageLabel> _buildLabels =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, DateTime> _startTimes =
             new(StringComparer.OrdinalIgnoreCase);
@@ -81,20 +81,20 @@ namespace Strazh.Analysis
                 });
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, BuildStageLabel buildLabel)
         {
             _names[projectFilePath] = projectName;
             _buildLabels[projectFilePath] = buildLabel;
             var now = DateTime.UtcNow;
             _startTimes[projectFilePath] = now;
-            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : buildLabel, now, now);
+            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : buildLabel.ToString(), now, now);
         }
 
         public void OnBuildCompleted(string projectFilePath)
         {
-            // Scan-pass entries are pre-work: silently remove them from the active display
+            // Building-pass entries are pre-work: silently remove them from the active display
             // rather than transitioning to "Loading" (they have no load or analysis step).
-            if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == "Building")
+            if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == BuildStageLabel.Building)
             {
                 _active.TryRemove(projectFilePath, out _);
             }

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -81,7 +81,7 @@ namespace Strazh.Analysis
                 });
         }
 
-        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel = "Building")
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit, string buildLabel)
         {
             _names[projectFilePath] = projectName;
             _buildLabels[projectFilePath] = buildLabel;
@@ -94,7 +94,7 @@ namespace Strazh.Analysis
         {
             // Scan-pass entries are pre-work: silently remove them from the active display
             // rather than transitioning to "Loading" (they have no load or analysis step).
-            if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == "Scanning")
+            if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == "Building")
             {
                 _active.TryRemove(projectFilePath, out _);
             }

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -113,7 +113,24 @@ namespace Strazh.Analysis
         {
             Interlocked.Increment(ref _completed);
             _active.TryRemove(projectFilePath, out _);
-            var markup = $"[yellow]Skipped[/] {Markup.Escape(filename)} ({Markup.Escape(reason)})";
+            string label;
+            if (reason.Contains("timed out"))
+            {
+                label = "[yellow]Timeout[/]";
+            }
+            else if (reason.Contains("could not be read"))
+            {
+                label = "[yellow]Unreadable[/]";
+            }
+            else if (reason.Contains("failed"))
+            {
+                label = "[red]Failed[/]";
+            }
+            else
+            {
+                label = "[yellow]Skipped[/]";
+            }
+            var markup = $"{label} {Markup.Escape(filename)} ({Markup.Escape(reason)})";
             _pendingWrites.Enqueue(() => AnsiConsole.MarkupLine(markup));
         }
 

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -2,22 +2,23 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console;
+using Spectre.Console.Rendering;
 using Strazh.Domain;
 
 namespace Strazh.Analysis
 {
     /// <summary>
     /// Implements <see cref="IAnalysisProgress"/> using Spectre.Console's Progress display.
-    /// A single <see cref="ProgressTask"/> holds a multi-line description that is rebuilt
-    /// every 80 ms by a ticker, always showing the most-recently-updated projects at the top
-    /// and capping the panel height to leave room for completed-project lines in the scrollback.
+    /// A single <see cref="ProgressTask"/> is rendered by a custom <see cref="PanelColumn"/>
+    /// that rebuilds a multi-line <see cref="Rows"/> renderable on every frame, always showing
+    /// the most-recently-updated projects at the top and capping height to leave room for
+    /// completed-project lines in the terminal scrollback.
     /// Completed and skipped lines are written via <see cref="AnsiConsole.MarkupLine"/>, which
-    /// Progress's render hook intercepts, clears the panel, writes the line to the terminal
-    /// scrollback, and re-renders the panel below — leaving the terminal state clean.
+    /// Progress's render hook intercepts, clears the panel, writes the line to the scrollback,
+    /// and re-renders the panel below — leaving the terminal state clean.
     /// All methods except <see cref="WrapAsync"/> may be called concurrently from multiple tasks.
     /// </summary>
     public sealed class SpectreConsoleProgress : IAnalysisProgress
@@ -44,10 +45,10 @@ namespace Strazh.Analysis
             _total = totalProjects;
             await AnsiConsole.Progress()
                 .AutoClear(true)
-                .Columns(new TaskDescriptionColumn { Alignment = Justify.Left })
+                .Columns(new PanelColumn(this))
                 .StartAsync(async ctx =>
                 {
-                    var panelTask = ctx.AddTask(BuildDescription());
+                    ctx.AddTask(string.Empty);
                     using var cts = new CancellationTokenSource();
                     var ticker = Task.Run(async () =>
                     {
@@ -55,7 +56,6 @@ namespace Strazh.Analysis
                         {
                             await Task.Delay(80).ConfigureAwait(false);
                             Interlocked.Increment(ref _tick);
-                            panelTask.Description = BuildDescription();
                         }
                     });
                     try
@@ -162,7 +162,7 @@ namespace Strazh.Analysis
             }
         }
 
-        private string BuildDescription()
+        private IRenderable BuildRenderable()
         {
             var frame = SpinnerFrames[Math.Abs(_tick) % SpinnerFrames.Length];
             // Reserve rows for completed-project lines so they remain visible above the panel.
@@ -175,23 +175,36 @@ namespace Strazh.Analysis
             var completed = Volatile.Read(ref _completed);
             var remaining = Math.Max(0, _total - completed);
 
-            var sb = new StringBuilder();
+            var rows = new List<IRenderable>(entries.Count + 2);
             foreach (var entry in entries)
             {
                 var elapsed = DateTime.UtcNow - entry.StartTime;
-                sb.Append($"[green]{frame}[/] {entry.Stage,-9} {Markup.Escape(entry.Name)}  [dim]{FormatElapsed(elapsed)}[/]\n");
+                rows.Add(new Markup(
+                    $"[green]{frame}[/] {entry.Stage,-9} {Markup.Escape(entry.Name)}  [dim]{FormatElapsed(elapsed)}[/]"));
             }
             if (hidden > 0)
             {
-                sb.Append($"[dim]  … {hidden} more running[/]\n");
+                rows.Add(new Markup($"[dim]  … {hidden} more running[/]"));
             }
-            sb.Append($"[dim]{completed} done · {remaining} remaining[/]");
-            return sb.ToString();
+            rows.Add(new Markup($"[dim]{completed} done · {remaining} remaining[/]"));
+            return new Rows(rows);
         }
 
         private static string FormatElapsed(TimeSpan elapsed)
             => elapsed.TotalSeconds < 60
                 ? $"{elapsed.TotalSeconds:F1}s"
                 : $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
+
+        /// <summary>
+        /// Single-column renderer for the panel task. Returns a multi-line
+        /// <see cref="Rows"/> renderable so each active project appears on its own line.
+        /// </summary>
+        private sealed class PanelColumn : ProgressColumn
+        {
+            private readonly SpectreConsoleProgress _owner;
+            internal PanelColumn(SpectreConsoleProgress owner) => _owner = owner;
+            public override IRenderable Render(RenderOptions options, ProgressTask task, TimeSpan deltaTime)
+                => _owner.BuildRenderable();
+        }
     }
 }

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Spectre.Console;
@@ -10,41 +12,61 @@ namespace Strazh.Analysis
 {
     /// <summary>
     /// Implements <see cref="IAnalysisProgress"/> using Spectre.Console's Progress display.
-    /// Each active project is a <see cref="ProgressTask"/>; completed and skipped lines are
-    /// written via <see cref="AnsiConsole.MarkupLine"/> which Progress's render hook intercepts,
-    /// clears the spinner area, writes the line to the terminal scrollback, and re-renders the
-    /// spinners below — leaving the terminal state clean.
+    /// A single <see cref="ProgressTask"/> holds a multi-line description that is rebuilt
+    /// every 80 ms by a ticker, always showing the most-recently-updated projects at the top
+    /// and capping the panel height to leave room for completed-project lines in the scrollback.
+    /// Completed and skipped lines are written via <see cref="AnsiConsole.MarkupLine"/>, which
+    /// Progress's render hook intercepts, clears the panel, writes the line to the terminal
+    /// scrollback, and re-renders the panel below — leaving the terminal state clean.
     /// All methods except <see cref="WrapAsync"/> may be called concurrently from multiple tasks.
     /// </summary>
     public sealed class SpectreConsoleProgress : IAnalysisProgress
     {
+        private record struct TaskEntry(string Name, string Stage, DateTime StartTime, DateTime LastChanged);
+
+        private readonly ConcurrentDictionary<string, TaskEntry> _active =
+            new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, string> _names =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, BuildStageLabel> _buildLabels =
             new(StringComparer.OrdinalIgnoreCase);
         private readonly ConcurrentDictionary<string, DateTime> _startTimes =
             new(StringComparer.OrdinalIgnoreCase);
-        private readonly ConcurrentDictionary<string, ProgressTask> _tasks =
-            new(StringComparer.OrdinalIgnoreCase);
-        private volatile ProgressContext? _ctx;
-        private int _completed;
+        private int _tick;
         private int _total;
+        private int _completed;
+
+        private static readonly string[] SpinnerFrames =
+            ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
 
         public async Task WrapAsync(int totalProjects, Func<Task> action)
         {
             _total = totalProjects;
             await AnsiConsole.Progress()
                 .AutoClear(true)
-                .HideCompleted(true)
-                .Columns(
-                    new SpinnerColumn(),
-                    new TaskDescriptionColumn { Alignment = Justify.Left }
-                )
+                .Columns(new TaskDescriptionColumn { Alignment = Justify.Left })
                 .StartAsync(async ctx =>
                 {
-                    _ctx = ctx;
-                    await action();
-                    _ctx = null;
+                    var panelTask = ctx.AddTask(BuildDescription());
+                    using var cts = new CancellationTokenSource();
+                    var ticker = Task.Run(async () =>
+                    {
+                        while (!cts.IsCancellationRequested)
+                        {
+                            await Task.Delay(80).ConfigureAwait(false);
+                            Interlocked.Increment(ref _tick);
+                            panelTask.Description = BuildDescription();
+                        }
+                    });
+                    try
+                    {
+                        await action();
+                    }
+                    finally
+                    {
+                        await cts.CancelAsync();
+                        await ticker;
+                    }
                 });
         }
 
@@ -52,49 +74,34 @@ namespace Strazh.Analysis
         {
             _names[projectFilePath] = projectName;
             _buildLabels[projectFilePath] = buildLabel;
-            _startTimes[projectFilePath] = DateTime.UtcNow;
-            if (_ctx is { } ctx)
-            {
-                var stage = isCacheHit ? "Cached" : buildLabel.ToString();
-                var task = ctx.AddTask($"{stage,-9} {Markup.Escape(projectName)}");
-                _tasks[projectFilePath] = task;
-            }
+            var now = DateTime.UtcNow;
+            _startTimes[projectFilePath] = now;
+            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : buildLabel.ToString(), now, now);
         }
 
         public void OnBuildCompleted(string projectFilePath)
         {
-            if (!_tasks.TryGetValue(projectFilePath, out var task))
-            {
-                return;
-            }
-            // Building-pass entries are pre-work: silently finish them rather than
+            // Building-pass entries are pre-work: silently remove them rather than
             // transitioning to "Loading" (they have no load or analysis step).
             if (_buildLabels.TryGetValue(projectFilePath, out var label) && label == BuildStageLabel.Building)
             {
-                task.StopTask();
+                _active.TryRemove(projectFilePath, out _);
             }
             else
             {
-                var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
-                task.Description = $"{"Loading",-9} {Markup.Escape(name)}";
+                UpdateEntry(projectFilePath, "Loading");
             }
         }
 
         public void OnStageChanged(string projectFilePath, string projectName, string stage)
         {
-            if (_tasks.TryGetValue(projectFilePath, out var task))
-            {
-                task.Description = $"{stage,-9} {Markup.Escape(projectName)}";
-            }
+            UpdateEntry(projectFilePath, stage);
         }
 
         public void OnProjectCompleted(string projectFilePath, int tripleCount)
         {
             Interlocked.Increment(ref _completed);
-            if (_tasks.TryGetValue(projectFilePath, out var task))
-            {
-                task.StopTask();
-            }
+            _active.TryRemove(projectFilePath, out _);
             var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
             var elapsed = DateTime.UtcNow - (_startTimes.TryGetValue(projectFilePath, out var st) ? st : DateTime.UtcNow);
             AnsiConsole.MarkupLine(
@@ -105,10 +112,7 @@ namespace Strazh.Analysis
         public void OnProjectSkipped(string projectFilePath, string filename, string reason)
         {
             Interlocked.Increment(ref _completed);
-            if (_tasks.TryGetValue(projectFilePath, out var task))
-            {
-                task.StopTask();
-            }
+            _active.TryRemove(projectFilePath, out _);
             string label;
             if (reason.Contains("timed out"))
             {
@@ -148,6 +152,41 @@ namespace Strazh.Analysis
                 AnsiConsole.WriteLine("");
             }
             AnsiConsole.WriteLine("]");
+        }
+
+        private void UpdateEntry(string projectFilePath, string stage)
+        {
+            if (_active.TryGetValue(projectFilePath, out var entry))
+            {
+                _active[projectFilePath] = entry with { Stage = stage, LastChanged = DateTime.UtcNow };
+            }
+        }
+
+        private string BuildDescription()
+        {
+            var frame = SpinnerFrames[Math.Abs(_tick) % SpinnerFrames.Length];
+            // Reserve rows for completed-project lines so they remain visible above the panel.
+            var maxContentRows = Math.Max(1, AnsiConsole.Console.Profile.Height - 5);
+            var entries = _active.Values
+                .OrderByDescending(e => e.LastChanged)
+                .Take(maxContentRows)
+                .ToList();
+            var hidden = Math.Max(0, _active.Count - entries.Count);
+            var completed = Volatile.Read(ref _completed);
+            var remaining = Math.Max(0, _total - completed);
+
+            var sb = new StringBuilder();
+            foreach (var entry in entries)
+            {
+                var elapsed = DateTime.UtcNow - entry.StartTime;
+                sb.Append($"[green]{frame}[/] {entry.Stage,-9} {Markup.Escape(entry.Name)}  [dim]{FormatElapsed(elapsed)}[/]\n");
+            }
+            if (hidden > 0)
+            {
+                sb.Append($"[dim]  … {hidden} more running[/]\n");
+            }
+            sb.Append($"[dim]{completed} done · {remaining} remaining[/]");
+            return sb.ToString();
         }
 
         private static string FormatElapsed(TimeSpan elapsed)

--- a/Strazh/Analysis/SpectreConsoleProgress.cs
+++ b/Strazh/Analysis/SpectreConsoleProgress.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Spectre.Console;
+using Spectre.Console.Rendering;
+using Strazh.Domain;
+
+namespace Strazh.Analysis
+{
+    /// <summary>
+    /// Implements <see cref="IAnalysisProgress"/> using Spectre.Console's Live display.
+    /// Active tasks are sorted by most-recently-updated so that any task receiving a stage
+    /// change floats to the top of the visible area, even when more projects are in flight
+    /// than the terminal can display at once.
+    /// All methods except <see cref="WrapAsync"/> may be called concurrently from multiple tasks.
+    /// </summary>
+    public sealed class SpectreConsoleProgress : IAnalysisProgress
+    {
+        private record struct TaskEntry(string Name, string Stage, DateTime StartTime, DateTime LastChanged);
+
+        private readonly ConcurrentDictionary<string, TaskEntry> _active =
+            new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, string> _names =
+            new(StringComparer.OrdinalIgnoreCase);
+        private readonly ConcurrentDictionary<string, DateTime> _startTimes =
+            new(StringComparer.OrdinalIgnoreCase);
+        private LiveDisplayContext? _ctx;
+        private int _tick;
+        private int _total;
+        private int _completed;
+
+        // Dots spinner frames — same set used by Spectre.Console's built-in SpinnerColumn.
+        private static readonly string[] SpinnerFrames =
+            ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+        public Task WrapAsync(int totalProjects, Func<Task> action)
+        {
+            _total = totalProjects;
+            return AnsiConsole.Live(new ActiveTasksRenderable(this))
+                .AutoClear(true)
+                .Overflow(VerticalOverflow.Ellipsis)
+                .StartAsync(async ctx =>
+                {
+                    _ctx = ctx;
+                    using var cts = new CancellationTokenSource();
+                    var ticker = Task.Run(async () =>
+                    {
+                        while (!cts.IsCancellationRequested)
+                        {
+                            await Task.Delay(80).ConfigureAwait(false);
+                            Interlocked.Increment(ref _tick);
+                            if (!cts.IsCancellationRequested)
+                            {
+                                ctx.Refresh();
+                            }
+                        }
+                    });
+                    try
+                    {
+                        await action();
+                    }
+                    finally
+                    {
+                        await cts.CancelAsync();
+                        await ticker;
+                    }
+                });
+        }
+
+        public void OnBuildStarted(string projectFilePath, string projectName, bool isCacheHit)
+        {
+            _names[projectFilePath] = projectName;
+            var now = DateTime.UtcNow;
+            _startTimes[projectFilePath] = now;
+            _active[projectFilePath] = new TaskEntry(projectName, isCacheHit ? "Cached" : "Building", now, now);
+            _ctx?.Refresh();
+        }
+
+        public void OnBuildCompleted(string projectFilePath)
+        {
+            UpdateEntry(projectFilePath, "Loading");
+        }
+
+        public void OnStageChanged(string projectFilePath, string projectName, string stage)
+        {
+            UpdateEntry(projectFilePath, stage);
+        }
+
+        public void OnProjectCompleted(string projectFilePath, int tripleCount)
+        {
+            Interlocked.Increment(ref _completed);
+            _active.TryRemove(projectFilePath, out _);
+            var name = _names.TryGetValue(projectFilePath, out var n) ? n : projectFilePath;
+            var elapsed = DateTime.UtcNow - (_startTimes.TryGetValue(projectFilePath, out var st) ? st : DateTime.UtcNow);
+            AnsiConsole.MarkupLine(
+                $"[green]✓[/] [bold]{Markup.Escape(name)}[/]  " +
+                $"[dim]{FormatElapsed(elapsed)}[/]  {tripleCount} triples");
+            _ctx?.Refresh();
+        }
+
+        public void OnProjectSkipped(string projectFilePath, string filename, string reason)
+        {
+            Interlocked.Increment(ref _completed);
+            _active.TryRemove(projectFilePath, out _);
+            AnsiConsole.MarkupLine($"[yellow]Skipped[/] {Markup.Escape(filename)} ({Markup.Escape(reason)})");
+            _ctx?.Refresh();
+        }
+
+        public void OnGroupingError(string projectName, IReadOnlyList<Triple> triples)
+        {
+            AnsiConsole.MarkupLine($"[red]Error[/] grouping triples for {Markup.Escape(projectName)}. Dumping detail:");
+            AnsiConsole.WriteLine("[");
+            var first = true;
+            foreach (var triple in triples)
+            {
+                if (!first)
+                {
+                    AnsiConsole.WriteLine(",");
+                }
+                AnsiConsole.Write($$"""{ "triple": {{ triple.ToInspection()}} }""");
+                first = false;
+            }
+            if (triples.Count > 0)
+            {
+                AnsiConsole.WriteLine("");
+            }
+            AnsiConsole.WriteLine("]");
+        }
+
+        private void UpdateEntry(string projectFilePath, string stage)
+        {
+            if (_active.TryGetValue(projectFilePath, out var entry))
+            {
+                _active[projectFilePath] = entry with { Stage = stage, LastChanged = DateTime.UtcNow };
+                _ctx?.Refresh();
+            }
+        }
+
+        private string GetSpinnerFrame()
+            => SpinnerFrames[Math.Abs(_tick) % SpinnerFrames.Length];
+
+        private (int completed, int remaining) GetCounts()
+        {
+            var completed = Volatile.Read(ref _completed);
+            return (completed, Math.Max(0, _total - completed));
+        }
+
+        private (List<TaskEntry> entries, int paddingRows) GetSortedEntries()
+        {
+            // Reserve 1 row for the summary line and 1 for breathing room.
+            var terminalHeight = AnsiConsole.Console.Profile.Height;
+            var maxContentRows = Math.Max(1, terminalHeight - 2);
+            var entries = _active.Values.OrderByDescending(e => e.LastChanged).Take(maxContentRows).ToList();
+            // Pad above the active entries so the summary line sits at the bottom of the terminal.
+            var paddingRows = Math.Max(0, maxContentRows - entries.Count);
+            return (entries, paddingRows);
+        }
+
+        private static string FormatElapsed(TimeSpan elapsed)
+            => elapsed.TotalSeconds < 60
+                ? $"{elapsed.TotalSeconds:F1}s"
+                : $"{(int)elapsed.TotalMinutes}m {elapsed.Seconds:D2}s";
+
+        /// <summary>
+        /// Live-renderable that rebuilds on every <see cref="LiveDisplayContext.Refresh"/> call,
+        /// always placing the most recently updated task at the top.
+        /// </summary>
+        private sealed class ActiveTasksRenderable : IRenderable
+        {
+            private readonly SpectreConsoleProgress _owner;
+
+            public ActiveTasksRenderable(SpectreConsoleProgress owner) => _owner = owner;
+
+            public Measurement Measure(RenderOptions options, int maxWidth) => new(0, maxWidth);
+
+            public IEnumerable<Segment> Render(RenderOptions options, int maxWidth)
+            {
+                var frame = _owner.GetSpinnerFrame();
+                var (entries, paddingRows) = _owner.GetSortedEntries();
+                var (completed, remaining) = _owner.GetCounts();
+
+                // Blank lines above the active-task block push it toward the bottom of the terminal.
+                for (var i = 0; i < paddingRows; i++)
+                {
+                    yield return Segment.LineBreak;
+                }
+
+                foreach (var entry in entries)
+                {
+                    var elapsed = DateTime.UtcNow - entry.StartTime;
+                    var line = new Markup(
+                        $"[green]{frame}[/] {entry.Stage,-9} {Markup.Escape(entry.Name)}  [dim]{FormatElapsed(elapsed)}[/]");
+                    foreach (var seg in ((IRenderable)line).Render(options, maxWidth))
+                    {
+                        yield return seg;
+                    }
+                    yield return Segment.LineBreak;
+                }
+
+                var summary = new Markup($"[dim]{completed} done · {remaining} remaining[/]");
+                foreach (var seg in ((IRenderable)summary).Render(options, maxWidth))
+                {
+                    yield return seg;
+                }
+                yield return Segment.LineBreak;
+            }
+        }
+    }
+}

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -11,6 +11,29 @@ namespace Strazh.Database
     {
         private const string CONNECTION = "neo4j://localhost:7687";
 
+        // All node labels that carry a pk property used as the MERGE key.
+        // A uniqueness constraint implicitly creates a B-tree index, turning each
+        // MERGE (n:Label { pk: "..." }) from a full label scan into an index lookup.
+        private static readonly string[] NodeLabels =
+            ["Class", "Interface", "Method", "File", "Folder", "Solution", "Project", "Package"];
+
+        public static async Task EnsureIndexes(CredentialsConfig credentials)
+        {
+            if (credentials == null)
+            {
+                throw new ArgumentException($"Please, provide credentials.");
+            }
+            Console.WriteLine("Ensuring Neo4j uniqueness constraints and indexes...");
+            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
+            foreach (var label in NodeLabels)
+            {
+                await session.RunAsync(
+                    $"CREATE CONSTRAINT {label.ToLowerInvariant()}_pk IF NOT EXISTS FOR (n:{label}) REQUIRE n.pk IS UNIQUE");
+            }
+            Console.WriteLine("Neo4j uniqueness constraints and indexes ready.");
+        }
+
         public static async Task DeleteData(CredentialsConfig credentials)
         {
             if (credentials == null)
@@ -30,17 +53,14 @@ namespace Strazh.Database
             {
                 throw new ArgumentException($"Please, provide credentials.");
             }
-            Console.WriteLine($"Code Knowledge Graph use \"{credentials.Database}\" Neo4j database.");
             await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {
-                Console.WriteLine($"Processing {triples.Count} triples...");
                 foreach (var triple in triples)
                 {
                     await session.RunAsync(triple.ToString());
                 }
-                Console.WriteLine($"Processing {triples.Count} triples complete.");
             }
             catch (Exception ex)
             {

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -9,22 +9,20 @@ namespace Strazh.Database
 {
     public static class DbManager
     {
-        private const string CONNECTION = "neo4j://localhost:7687";
-
         // All node labels that carry a pk property used as the MERGE key.
         // A uniqueness constraint implicitly creates a B-tree index, turning each
         // MERGE (n:Label { pk: "..." }) from a full label scan into an index lookup.
         private static readonly string[] NodeLabels =
             ["Class", "Interface", "Method", "File", "Folder", "Solution", "Project", "Package"];
 
-        public static async Task EnsureIndexes(CredentialsConfig credentials)
+        public static async Task EnsureIndexes(CredentialsConfig credentials, string neo4jUrl)
         {
             if (credentials == null)
             {
                 throw new ArgumentException($"Please, provide credentials.");
             }
             Console.WriteLine("Ensuring Neo4j uniqueness constraints and indexes...");
-            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var driver = GraphDatabase.Driver(neo4jUrl, AuthTokens.Basic(credentials.User, credentials.Password));
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             foreach (var label in NodeLabels)
             {
@@ -34,26 +32,26 @@ namespace Strazh.Database
             Console.WriteLine("Neo4j uniqueness constraints and indexes ready.");
         }
 
-        public static async Task DeleteData(CredentialsConfig credentials)
+        public static async Task DeleteData(CredentialsConfig credentials, string neo4jUrl)
         {
             if (credentials == null)
             {
                 throw new ArgumentException($"Please, provide credentials.");
             }
             Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database...");
-            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var driver = GraphDatabase.Driver(neo4jUrl, AuthTokens.Basic(credentials.User, credentials.Password));
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             await session.RunAsync("MATCH (n) DETACH DELETE n;");
             Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database complete.");
         }
 
-        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials)
+        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials, string neo4jUrl)
         {
             if (credentials == null)
             {
                 throw new ArgumentException($"Please, provide credentials.");
             }
-            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var driver = GraphDatabase.Driver(neo4jUrl, AuthTokens.Basic(credentials.User, credentials.Password));
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -11,7 +11,20 @@ namespace Strazh.Database
     {
         private const string CONNECTION = "neo4j://localhost:7687";
 
-        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials, bool isDelete)
+        public static async Task DeleteData(CredentialsConfig credentials)
+        {
+            if (credentials == null)
+            {
+                throw new ArgumentException($"Please, provide credentials.");
+            }
+            Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database...");
+            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
+            await session.RunAsync("MATCH (n) DETACH DELETE n;");
+            Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database complete.");
+        }
+
+        public static async Task InsertData(IList<Triple> triples, CredentialsConfig credentials)
         {
             if (credentials == null)
             {
@@ -22,12 +35,6 @@ namespace Strazh.Database
             await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {
-                if (isDelete)
-                {
-                    Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database...");
-                    await session.RunAsync("MATCH (n) DETACH DELETE n;");
-                    Console.WriteLine($"Deleting graph data of \"{credentials.Database}\" database complete.");
-                }
                 Console.WriteLine($"Processing {triples.Count} triples...");
                 foreach (var triple in triples)
                 {

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -13,7 +13,7 @@ namespace Strazh.Database
         // A uniqueness constraint implicitly creates a B-tree index, turning each
         // MERGE (n:Label { pk: "..." }) from a full label scan into an index lookup.
         private static readonly string[] NodeLabels =
-            ["Class", "Interface", "Method", "File", "Folder", "Solution", "Project", "Package"];
+            ["Class", "Interface", "Method", "File", "Folder", "Solution", "Project", "Package", "Repository"];
 
         public static async Task EnsureIndexes(CredentialsConfig credentials, string neo4jUrl)
         {

--- a/Strazh/Database/DbManager.cs
+++ b/Strazh/Database/DbManager.cs
@@ -18,8 +18,8 @@ namespace Strazh.Database
                 throw new ArgumentException($"Please, provide credentials.");
             }
             Console.WriteLine($"Code Knowledge Graph use \"{credentials.Database}\" Neo4j database.");
-            var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
-            var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
+            await using var driver = GraphDatabase.Driver(CONNECTION, AuthTokens.Basic(credentials.User, credentials.Password));
+            await using var session = driver.AsyncSession(o => o.WithDatabase(credentials.Database));
             try
             {
                 if (isDelete)
@@ -38,11 +38,6 @@ namespace Strazh.Database
             catch (Exception ex)
             {
                 Console.WriteLine(ex.Message);
-            }
-            finally
-            {
-                await session.CloseAsync();
-                await driver.CloseAsync();
             }
         }
     }

--- a/Strazh/Database/ITripleStore.cs
+++ b/Strazh/Database/ITripleStore.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Domain;
+
+namespace Strazh.Database
+{
+    /// <summary>
+    /// Abstracts the backing store that receives triples produced by the analysis pipeline.
+    /// The production implementation writes to Neo4j; a test double can collect triples
+    /// in memory for assertion without requiring a live database connection.
+    /// </summary>
+    public interface ITripleStore
+    {
+        /// <summary>
+        /// Ensures that the store is ready to accept triples (e.g. creates indexes in Neo4j).
+        /// Called once before any <see cref="InsertAsync"/> calls.
+        /// </summary>
+        Task EnsureIndexesAsync();
+
+        /// <summary>
+        /// Removes all existing data from the store.
+        /// Called at most once, before any <see cref="InsertAsync"/> calls.
+        /// </summary>
+        Task DeleteAllAsync();
+
+        /// <summary>
+        /// Persists a batch of deduplicated triples for a single project.
+        /// May be called concurrently from multiple tasks.
+        /// </summary>
+        Task InsertAsync(IList<Triple> triples);
+    }
+}

--- a/Strazh/Database/Neo4jTripleStore.cs
+++ b/Strazh/Database/Neo4jTripleStore.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Strazh.Domain;
+using static Strazh.Analysis.AnalyzerConfig;
+
+namespace Strazh.Database
+{
+    /// <summary>
+    /// Production <see cref="ITripleStore"/> implementation backed by Neo4j.
+    /// Delegates to the static <see cref="DbManager"/> helpers.
+    /// </summary>
+    public class Neo4jTripleStore(CredentialsConfig credentials, string neo4jUrl) : ITripleStore
+    {
+        public Task EnsureIndexesAsync() =>
+            DbManager.EnsureIndexes(credentials, neo4jUrl);
+
+        public Task DeleteAllAsync() =>
+            DbManager.DeleteData(credentials, neo4jUrl);
+
+        public Task InsertAsync(IList<Triple> triples) =>
+            DbManager.InsertData(triples, credentials, neo4jUrl);
+    }
+}

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -36,46 +36,26 @@ namespace Strazh.Domain
 
     // Code
 
-    public abstract class CodeNode : Node
+    public abstract class CodeNode(string fullName, string name, string[] modifiers = null) : Node(fullName, name)
     {
-        public CodeNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name)
-        {
-
-            Modifiers = modifiers == null ? "" : string.Join(", ", modifiers);
-        }
-
-        public string Modifiers { get; }
+        public string Modifiers { get; } = modifiers == null ? "" : string.Join(", ", modifiers);
 
         public override string Set(string node)
             => $"{base.Set(node)}{(string.IsNullOrEmpty(Modifiers) ? "" : $", {node}.modifiers = \"{Modifiers}\"")}";
     }
 
-    public abstract class TypeNode : CodeNode
-    {
-        public TypeNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-    }
+    public abstract class TypeNode(string fullName, string name, string[] modifiers = null)
+        : CodeNode(fullName, name, modifiers);
 
-    public class ClassNode : TypeNode
+    public class ClassNode(string fullName, string name, string[] modifiers = null)
+        : TypeNode(fullName, name, modifiers)
     {
-        public ClassNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-
         public override string Label { get; } = "Class";
     }
 
-    public class InterfaceNode : TypeNode
+    public class InterfaceNode(string fullName, string name, string[] modifiers = null)
+        : TypeNode(fullName, name, modifiers)
     {
-        public InterfaceNode(string fullName, string name, string[] modifiers = null)
-            : base(fullName, name, modifiers)
-        {
-        }
-
         public override string Label { get; } = "Interface";
     }
 
@@ -106,19 +86,13 @@ namespace Strazh.Domain
 
     // Structure
 
-    public class FileNode : Node
+    public class FileNode(string fullName, string name) : Node(fullName, name)
     {
-        public FileNode(string fullName, string name)
-            : base(fullName, name) { }
-
         public override string Label { get; } = "File";
     }
 
-    public class FolderNode : Node
+    public class FolderNode(string fullName, string name) : Node(fullName, name)
     {
-        public FolderNode(string fullName, string name)
-            : base(fullName, name) { }
-
         public override string Label { get; } = "Folder";
     }
 
@@ -127,13 +101,10 @@ namespace Strazh.Domain
         public override string Label => "Solution";
     }
 
-    public class ProjectNode : Node
+    public class ProjectNode(string fullName, string name) : Node(fullName, name)
     {
         public ProjectNode(string name)
             : this(name, name) { }
-
-        public ProjectNode(string fullName, string name)
-            : base(fullName, name) { }
 
         public override string Label { get; } = "Project";
     }

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -122,6 +122,11 @@ namespace Strazh.Domain
         public override string Label { get; } = "Project";
     }
 
+    public class RepositoryNode(string name) : Node(name, name)
+    {
+        public override string Label { get; } = "Repository";
+    }
+
     public class PackageNode : Node
     {
         public PackageNode(string fullName, string name, string version)

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
 
 namespace Strazh.Domain
 {
@@ -24,7 +27,17 @@ namespace Strazh.Domain
 
         protected virtual void SetPrimaryKey()
         {
-            Pk = FullName.GetHashCode().ToString();
+            Pk = DeterministicHash(FullName);
+        }
+
+        // string.GetHashCode() is randomized per-process in .NET Core and later, so using it
+        // as a Neo4j pk causes every run to generate different values for the same node,
+        // defeating MERGE and creating duplicate nodes. MD5 gives a stable, collision-resistant
+        // identifier across runs. (This is not a security use — stability is all that matters.)
+        protected static string DeterministicHash(string value)
+        {
+            var bytes = MD5.HashData(Encoding.UTF8.GetBytes(value));
+            return Convert.ToHexString(bytes);
         }
 
         public virtual string Set(string node) => 
@@ -80,7 +93,7 @@ namespace Strazh.Domain
 
         protected override void SetPrimaryKey()
         {
-            Pk = $"{FullName}{Arguments}{ReturnType}".GetHashCode().ToString();
+            Pk = DeterministicHash($"{FullName}{Arguments}{ReturnType}");
         }
     }
 
@@ -127,7 +140,7 @@ namespace Strazh.Domain
 
         protected override void SetPrimaryKey()
         {
-            Pk = $"{FullName}{Version}".GetHashCode().ToString();
+            Pk = DeterministicHash($"{FullName}{Version}");
         }
     }
 }

--- a/Strazh/Domain/Nodes.cs
+++ b/Strazh/Domain/Nodes.cs
@@ -104,9 +104,41 @@ namespace Strazh.Domain
         public override string Label { get; } = "File";
     }
 
-    public class FolderNode(string fullName, string name) : Node(fullName, name)
+    public enum FolderKind
     {
+        Regular,
+        Submodule,
+    }
+
+    public class FolderNode : Node
+    {
+        public FolderNode(string fullName, string name)
+            : this(fullName, name, FolderKind.Regular) { }
+
+        public FolderNode(string fullName, string name, FolderKind kind)
+            : base(fullName, name)
+        {
+            Kind = kind;
+            SetPrimaryKey();
+        }
+
         public override string Label { get; } = "Folder";
+
+        public FolderKind Kind { get; }
+
+        // Kind is part of the PK so two folders at the same path with different kinds
+        // (e.g. a Regular folder created by the file chain vs. a Submodule mount-point
+        // node) are distinct nodes in the graph rather than colliding on MERGE.
+        protected override void SetPrimaryKey()
+        {
+            Pk = DeterministicHash($"{FullName}|{Kind}");
+        }
+
+        // Only write kind when non-default to keep the property set clean on regular folders.
+        public override string Set(string node)
+            => Kind == FolderKind.Regular
+                ? base.Set(node)
+                : $"{base.Set(node)}, {node}.kind = \"{Kind}\"";
     }
 
     public class SolutionNode(string name) : Node(name, name)

--- a/Strazh/Domain/Triples.cs
+++ b/Strazh/Domain/Triples.cs
@@ -1,19 +1,12 @@
 namespace Strazh.Domain
 {
-    public abstract class Triple : IInspectable
+    public abstract class Triple(Node nodeA, Node nodeB, Relationship relationship) : IInspectable
     {
-        public Node NodeA { get; set; }
+        public Node NodeA { get; set; } = nodeA;
 
-        public Node NodeB { get; set; }
+        public Node NodeB { get; set; } = nodeB;
 
-        public Relationship Relationship { get; set; }
-
-        protected Triple(Node nodeA, Node nodeB, Relationship relationship)
-        {
-            NodeA = nodeA;
-            NodeB = nodeB;
-            Relationship = relationship;
-        }
+        public Relationship Relationship { get; set; } = relationship;
 
         public override string ToString()
             => $"MERGE (a:{NodeA.Label} {{ pk: \"{NodeA.Pk}\" }}) ON CREATE SET {NodeA.Set("a")} ON MATCH SET {NodeA.Set("a")} MERGE (b:{NodeB.Label} {{ pk: \"{NodeB.Pk}\" }}) ON CREATE SET {NodeB.Set("b")} ON MATCH SET {NodeB.Set("b")} MERGE (a)-[:{Relationship.Type}]->(b);";
@@ -24,23 +17,13 @@ namespace Strazh.Domain
 
     // Structure
 
-    public class TripleDependsOnProject : Triple
-    {
-        public TripleDependsOnProject(
-            ProjectNode projectA,
-            ProjectNode projectB)
-            : base(projectA, projectB, new DependsOnRelationship())
-        { }
-    }
+    public class TripleDependsOnProject(
+        ProjectNode projectA,
+        ProjectNode projectB) : Triple(projectA, projectB, new DependsOnRelationship());
 
-    public class TripleDependsOnPackage : Triple
-    {
-        public TripleDependsOnPackage(
-            ProjectNode projectA,
-            PackageNode packageB)
-            : base(projectA, packageB, new DependsOnRelationship())
-        { }
-    }
+    public class TripleDependsOnPackage(
+        ProjectNode projectA,
+        PackageNode packageB) : Triple(projectA, packageB, new DependsOnRelationship());
 
     public class TripleIncludedIn : Triple
     {
@@ -71,53 +54,27 @@ namespace Strazh.Domain
 
     }
     
-    public class TripleContains : Triple
-    {
-        public TripleContains(
-            SolutionNode solution,
-            ProjectNode project)
-            : base(solution, project, new ContainsRelationship())
-        {
-        }
-    }
+    public class TripleContains(
+        SolutionNode solution,
+        ProjectNode project) : Triple(solution, project, new ContainsRelationship());
 
-    public class TripleDeclaredAt : Triple
-    {
-        public TripleDeclaredAt(
-            TypeNode typeA,
-            FileNode fileB)
-            : base(typeA, fileB, new DeclaredAtRelationship())
-        { }
-    }
+    public class TripleDeclaredAt(
+        TypeNode typeA,
+        FileNode fileB) : Triple(typeA, fileB, new DeclaredAtRelationship());
 
     // Code
 
-    public class TripleInvoke : Triple
-    {
-        public TripleInvoke(
-            MethodNode methodA,
-            MethodNode methodB)
-            : base(methodA, methodB, new InvokeRelationship())
-        { }
-    }
+    public class TripleInvoke(
+        MethodNode methodA,
+        MethodNode methodB) : Triple(methodA, methodB, new InvokeRelationship());
 
-    public class TripleHave : Triple
-    {
-        public TripleHave(
-            TypeNode typeA,
-            MethodNode methodB)
-            : base(typeA, methodB, new HaveRelationship())
-        { }
-    }
+    public class TripleHave(
+        TypeNode typeA,
+        MethodNode methodB) : Triple(typeA, methodB, new HaveRelationship());
 
-    public class TripleConstruct : Triple
-    {
-        public TripleConstruct(
-            MethodNode methodA,
-            ClassNode classB)
-            : base(methodA, classB, new ConstructRelationship())
-        { }
-    }
+    public class TripleConstruct(
+        MethodNode methodA,
+        ClassNode classB) : Triple(methodA, classB, new ConstructRelationship());
 
     public class TripleOfType : Triple
     {

--- a/Strazh/Domain/Triples.cs
+++ b/Strazh/Domain/Triples.cs
@@ -52,6 +52,12 @@ namespace Strazh.Domain
             : base(contentA, contentB, new IncludedInRelationship())
         { }
 
+        public TripleIncludedIn(
+            FolderNode folder,
+            RepositoryNode repository)
+            : base(folder, repository, new IncludedInRelationship())
+        { }
+
     }
     
     public class TripleContains(

--- a/Strazh/Healthcheck.cs
+++ b/Strazh/Healthcheck.cs
@@ -8,9 +8,9 @@ namespace Strazh
 {
     public static class Healthcheck
     {
-        public static async Task<bool> IsNeo4jReady(short retry = 3)
+        public static async Task<bool> IsNeo4jReady(string neo4jUrl, short retry = 3)
         {
-            var statusCode = await GetStatusCode();
+            var statusCode = await GetStatusCode(neo4jUrl);
             if (statusCode == HttpStatusCode.OK)
             {
                 Console.WriteLine("Neo4j is ready to use.");
@@ -20,17 +20,19 @@ namespace Strazh
             {
                 Console.WriteLine("Waiting for Neo4j...");
                 await Task.Delay(10000);
-                return await IsNeo4jReady(--retry);
+                return await IsNeo4jReady(neo4jUrl, --retry);
             }
             return false;
         }
 
-        private static async Task<HttpStatusCode> GetStatusCode()
+        private static async Task<HttpStatusCode> GetStatusCode(string neo4jUrl)
         {
             try
             {
+                var uri = new Uri(neo4jUrl);
+                var httpCheckUrl = $"http://{uri.Host}:7474/";
                 using var client = new HttpClient();
-                var result = await client.GetAsync("http://localhost:7474/");
+                var result = await client.GetAsync(httpCheckUrl);
                 return result.StatusCode;
             }
             catch

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -64,6 +64,12 @@ namespace Strazh
             };
             rootCommand.Options.Add(optionBuildLogDir);
 
+            var optionNeo4jUrl = new Option<string>("--neo4j-url", "-u")
+            {
+                Description = "optional connection URL for the Neo4j database (default `neo4j://localhost:7687`)"
+            };
+            rootCommand.Options.Add(optionNeo4jUrl);
+
             rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
             {
                 await BuildKnowledgeGraph(new AnalyzerConfig.Options(
@@ -74,7 +80,8 @@ namespace Strazh
                     Projects: parseResult.GetValue(optionProjects),
                     CacheDirectory: parseResult.GetValue(optionCache),
                     NoCache: parseResult.GetValue(optionNoCache),
-                    BuildLogDirectory: parseResult.GetValue(optionBuildLogDir)
+                    BuildLogDirectory: parseResult.GetValue(optionBuildLogDir),
+                    Neo4jUrl: parseResult.GetValue(optionNeo4jUrl)
                 ));
             });
 
@@ -91,7 +98,7 @@ namespace Strazh
                     Console.WriteLine("Please submit only one thing: `--solution` (-s) or `--projects` (-p)");
                     return;
                 }
-                var isNeo4jReady = await Healthcheck.IsNeo4jReady();
+                var isNeo4jReady = await Healthcheck.IsNeo4jReady(config.Neo4jUrl);
                 if (!isNeo4jReady)
                 {
                     Console.WriteLine("Strazh failed to start. There is no Neo4j instance ready to use.");

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -99,7 +99,12 @@ namespace Strazh
                 }
 
                 Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");
-                await Analyzer.Analyze(config, new SpectreConsoleProgress());
+                var runLogPath = Path.Combine(
+                    config.BuildLogDirectory!,
+                    $"strazh-run-{DateTime.UtcNow:yyyy-MM-ddTHHmmssZ}.log");
+                using var fileProgress = new FileAnalysisProgress(runLogPath);
+                var progress = new CompositeAnalysisProgress(new SpectreConsoleProgress(), fileProgress);
+                await Analyzer.Analyze(config, progress);
                 Console.WriteLine("Code Knowledge Graph created.");
             }
             catch (Exception ex)

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -45,6 +45,12 @@ namespace Strazh
             };
             rootCommand.Options.Add(optionProjects);
 
+            var optionCache = new Option<string>("--cache")
+            {
+                Description = "optional path to a directory where MSBuild binary logs are cached; defaults to the platform application data folder (e.g. ~/Library/Application Support/strazh/cache on macOS)"
+            };
+            rootCommand.Options.Add(optionCache);
+
             rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
             {
                 await BuildKnowledgeGraph(
@@ -52,13 +58,14 @@ namespace Strazh
                     parseResult.GetValue(optionMode),
                     parseResult.GetValue(optionDelete),
                     parseResult.GetValue(optionSolution),
-                    parseResult.GetValue(optionProjects));
+                    parseResult.GetValue(optionProjects),
+                    parseResult.GetValue(optionCache));
             });
 
             return await rootCommand.Parse(args).InvokeAsync();
         }
 
-        private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects)
+        private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
         {
             try
             {
@@ -67,7 +74,8 @@ namespace Strazh
                        tier,
                        delete,
                        solution,
-                       projects
+                       projects,
+                       cacheDirectory
                    );
                 if (!config.IsValid)
                 {

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -90,7 +90,7 @@ namespace Strazh
                 }
 
                 Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");
-                await Analyzer.Analyze(config);
+                await Analyzer.Analyze(config, new SpectreConsoleProgress());
                 Console.WriteLine("Code Knowledge Graph created.");
             }
             catch (Exception ex)

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Strazh.Analysis;
+using Strazh.Database;
 
 namespace Strazh
 {
@@ -111,7 +112,8 @@ namespace Strazh
                     $"strazh-run-{DateTime.UtcNow:yyyy-MM-ddTHHmmssZ}.log");
                 using var fileProgress = new FileAnalysisProgress(runLogPath);
                 var progress = new CompositeAnalysisProgress(new SpectreConsoleProgress(), fileProgress);
-                await Analyzer.Analyze(config, progress);
+                var store = new Neo4jTripleStore(config.Credentials, config.Neo4jUrl);
+                await Analyzer.Analyze(config, progress, store);
                 Console.WriteLine("Code Knowledge Graph created.");
             }
             catch (Exception ex)

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -1,53 +1,61 @@
-﻿using System;
+using System;
 using System.CommandLine;
-using System.CommandLine.Invocation;
-using Microsoft.Build.Logging.StructuredLogger;
+using System.Threading;
+using System.Threading.Tasks;
 using Strazh.Analysis;
-using Task = System.Threading.Tasks.Task;
 
 namespace Strazh
 {
     public class Program
     {
 
-        public static async Task Main(params string[] args)
+        public static async Task<int> Main(params string[] args)
         {
-#if DEBUG
-            // There is an issue with using Neo4j.Driver 4.2.0
-            // System.IO.FileNotFoundException: Could not load file or assembly '4.2.37.0'. The system cannot find the file specified.
-            // Workaround to load assembly and avoid issue 
-            System.Reflection.Assembly.Load("Neo4j.Driver");
-#endif
             var rootCommand = new RootCommand();
 
-            var optionCredentials = new Option<string>("--credentials", "required information in format `dbname:user:password` to connect to Neo4j Database");
-            optionCredentials.AddAlias("-c");
-            optionCredentials.IsRequired = true;
-            rootCommand.Add(optionCredentials);
+            var optionCredentials = new Option<string>("--credentials", "-c")
+            {
+                Description = "required information in format `dbname:user:password` to connect to Neo4j Database",
+                Required = true
+            };
+            rootCommand.Options.Add(optionCredentials);
 
-            var optionMode = new Option<string>("--tier", "optional flag as `project` or `code` or 'all' (default `all`) selected tier to scan in a codebase");
-            optionMode.AddAlias("-t");
-            optionMode.IsRequired = false;
-            rootCommand.Add(optionMode);
+            var optionMode = new Option<string>("--tier", "-t")
+            {
+                Description = "optional flag as `project` or `code` or 'all' (default `all`) selected tier to scan in a codebase"
+            };
+            rootCommand.Options.Add(optionMode);
 
-            var optionDelete = new Option<string>("--delete", "optional flag as `true` or `false` or no flag (default `true`) to delete data in graph before execution");
-            optionDelete.AddAlias("-d");
-            optionDelete.IsRequired = false;
-            rootCommand.Add(optionDelete);
+            var optionDelete = new Option<string>("--delete", "-d")
+            {
+                Description = "optional flag as `true` or `false` or no flag (default `true`) to delete data in graph before execution"
+            };
+            rootCommand.Options.Add(optionDelete);
 
-            var optionSolution = new Option<string>("--solution", "optional absolute path to only one `.sln` file (can't be used together with -p / --projects)");
-            optionSolution.AddAlias("-s");
-            optionSolution.IsRequired = false;
-            rootCommand.Add(optionSolution);
+            var optionSolution = new Option<string>("--solution", "-s")
+            {
+                Description = "optional absolute path to only one `.sln` file (can't be used together with -p / --projects)"
+            };
+            rootCommand.Options.Add(optionSolution);
 
-            var optionProjects = new Option<string[]>("--projects", "optional list of absolute path to one or many `.csproj` files (can't be used together with -s / --solution)");
-            optionProjects.AddAlias("-p");
-            optionProjects.IsRequired = false;
-            rootCommand.Add(optionProjects);
+            var optionProjects = new Option<string[]>("--projects", "-p")
+            {
+                Description = "optional list of absolute path to one or many `.csproj` files (can't be used together with -s / --solution)",
+                AllowMultipleArgumentsPerToken = true
+            };
+            rootCommand.Options.Add(optionProjects);
 
-            rootCommand.SetHandler(BuildKnowledgeGraph, optionCredentials, optionMode, optionDelete, optionSolution, optionProjects);
+            rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
+            {
+                await BuildKnowledgeGraph(
+                    parseResult.GetValue(optionCredentials),
+                    parseResult.GetValue(optionMode),
+                    parseResult.GetValue(optionDelete),
+                    parseResult.GetValue(optionSolution),
+                    parseResult.GetValue(optionProjects));
+            });
 
-            await rootCommand.InvokeAsync(args);
+            return await rootCommand.Parse(args).InvokeAsync();
         }
 
         private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects)
@@ -73,7 +81,7 @@ namespace Strazh
                     return;
                 }
 
-                Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");                
+                Console.WriteLine($"Brewing a Code Knowledge Graph of tier \"{config.Tier}\".");
                 await Analyzer.Analyze(config);
                 Console.WriteLine("Code Knowledge Graph created.");
             }

--- a/Strazh/Program.cs
+++ b/Strazh/Program.cs
@@ -1,5 +1,6 @@
 using System;
 using System.CommandLine;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using Strazh.Analysis;
@@ -51,32 +52,40 @@ namespace Strazh
             };
             rootCommand.Options.Add(optionCache);
 
+            var optionNoCache = new Option<bool>("--no-cache")
+            {
+                Description = "when set, rebuilds all projects and writes fresh cache entries without reading any existing cached binlogs"
+            };
+            rootCommand.Options.Add(optionNoCache);
+
+            var optionBuildLogDir = new Option<string>("--build-log-dir")
+            {
+                Description = "optional path to a directory where per-project MSBuild build logs are written; defaults to the platform application data folder (e.g. ~/Library/Application Support/strazh/logs on macOS)"
+            };
+            rootCommand.Options.Add(optionBuildLogDir);
+
             rootCommand.SetAction(async (ParseResult parseResult, CancellationToken token) =>
             {
-                await BuildKnowledgeGraph(
-                    parseResult.GetValue(optionCredentials),
-                    parseResult.GetValue(optionMode),
-                    parseResult.GetValue(optionDelete),
-                    parseResult.GetValue(optionSolution),
-                    parseResult.GetValue(optionProjects),
-                    parseResult.GetValue(optionCache));
+                await BuildKnowledgeGraph(new AnalyzerConfig.Options(
+                    Credentials: parseResult.GetValue(optionCredentials),
+                    Tier: parseResult.GetValue(optionMode),
+                    Delete: parseResult.GetValue(optionDelete),
+                    Solution: parseResult.GetValue(optionSolution),
+                    Projects: parseResult.GetValue(optionProjects),
+                    CacheDirectory: parseResult.GetValue(optionCache),
+                    NoCache: parseResult.GetValue(optionNoCache),
+                    BuildLogDirectory: parseResult.GetValue(optionBuildLogDir)
+                ));
             });
 
             return await rootCommand.Parse(args).InvokeAsync();
         }
 
-        private static async Task BuildKnowledgeGraph(string credentials, string tier, string delete, string solution, string[] projects, string? cacheDirectory = null)
+        private static async Task BuildKnowledgeGraph(AnalyzerConfig.Options options)
         {
             try
             {
-                var config = new AnalyzerConfig(
-                       credentials,
-                       tier,
-                       delete,
-                       solution,
-                       projects,
-                       cacheDirectory
-                   );
+                var config = new AnalyzerConfig(options);
                 if (!config.IsValid)
                 {
                     Console.WriteLine("Please submit only one thing: `--solution` (-s) or `--projects` (-p)");

--- a/Strazh/Strazh.csproj
+++ b/Strazh/Strazh.csproj
@@ -10,6 +10,10 @@
   <ItemGroup>
     <PackageReference Include="Buildalyzer" Version="8.0.0" />
     <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
+    <!-- Override the version of MSBuild.StructuredLogger that Buildalyzer 8.0.0 pulls in
+         (2.2.158). The .NET 10 SDK writes binlogs in a format that requires 2.3.x+ to parse;
+         without this override every binlog read returns empty results on .NET 10 hosts. -->
+    <PackageReference Include="MSBuild.StructuredLogger" Version="2.3.154" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
     <PackageReference Include="Neo4j.Driver" Version="6.0.0" />

--- a/Strazh/Strazh.csproj
+++ b/Strazh/Strazh.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
     <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="Spectre.Console" Version="0.55.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 

--- a/Strazh/Strazh.csproj
+++ b/Strazh/Strazh.csproj
@@ -2,19 +2,18 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Version>1.0.0-beta.1</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="7.1.0" />
-    <PackageReference Include="Buildalyzer.Workspaces" Version="7.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.13.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="4.13.0" />
-    <PackageReference Include="Neo4j.Driver" Version="5.27.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Buildalyzer" Version="8.0.0" />
+    <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
+    <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
+    <PackageReference Include="System.CommandLine" Version="2.0.5" />
   </ItemGroup>
 
 </Project>

--- a/Strazh/Strazh.csproj
+++ b/Strazh/Strazh.csproj
@@ -8,17 +8,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Buildalyzer" Version="8.0.0" />
-    <PackageReference Include="Buildalyzer.Workspaces" Version="8.0.0" />
-    <!-- Override the version of MSBuild.StructuredLogger that Buildalyzer 8.0.0 pulls in
-         (2.2.158). The .NET 10 SDK writes binlogs in a format that requires 2.3.x+ to parse;
-         without this override every binlog read returns empty results on .NET 10 hosts. -->
-    <PackageReference Include="MSBuild.StructuredLogger" Version="2.3.154" />
+    <PackageReference Include="MScottFord.Forks.Buildalyzer" Version="9.0.0-alpha" />
+    <PackageReference Include="MScottFord.Forks.Buildalyzer.Workspaces" Version="9.0.0-alpha" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="5.3.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Csharp" Version="5.3.0" />
+    <!-- Pin patched version to suppress NU1903 vulnerability warnings (GHSA-37gx-xxp4-5rgx, GHSA-w3x6-4m5h-cxqf).
+         System.Security.Cryptography.Xml 10.0.1 is pulled in transitively on net10.0 targets. -->
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.6" />
     <PackageReference Include="Neo4j.Driver" Version="6.0.0" />
-    <PackageReference Include="Spectre.Console" Version="0.55.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.5" />
+    <PackageReference Include="Spectre.Console" Version="0.55.2" />
+    <PackageReference Include="System.CommandLine" Version="2.0.6" />
   </ItemGroup>
 
 </Project>

--- a/Strazh/Strazh.sln
+++ b/Strazh/Strazh.sln
@@ -17,24 +17,66 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectB", "..
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{EF685B52-D0F9-4350-9956-90CF2DE13610}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests", "..\Strazh.Tests\Strazh.Tests.csproj", "{267F7E5F-419B-434D-B9C0-27A12FC95B77}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x64.Build.0 = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Debug|x86.Build.0 = Debug|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x64.ActiveCfg = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x64.Build.0 = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x86.ActiveCfg = Release|Any CPU
+		{1C92D6A7-867F-42CC-933B-DB78249BA75B}.Release|x86.Build.0 = Release|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x64.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|x86.Build.0 = Debug|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x64.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x64.Build.0 = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x86.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|x86.Build.0 = Release|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x64.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|x86.Build.0 = Debug|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x64.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x64.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x86.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|x86.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x64.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Debug|x86.Build.0 = Debug|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|Any CPU.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x64.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x64.Build.0 = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x86.ActiveCfg = Release|Any CPU
+		{267F7E5F-419B-434D-B9C0-27A12FC95B77}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SystemUnderTest/SystemUnderTest.sln
+++ b/SystemUnderTest/SystemUnderTest.sln
@@ -1,0 +1,25 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectA", "Strazh.Tests.ProjectA\Strazh.Tests.ProjectA.csproj", "{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Strazh.Tests.ProjectB", "Strazh.Tests.ProjectB\Strazh.Tests.ProjectB.csproj", "{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CBE72A8F-DDA9-45DC-987B-B55FA9A3EC2C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D8AEF0F8-1FC1-4CAF-AC35-C62D29A83ABC}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/binlog-reader.cs
+++ b/binlog-reader.cs
@@ -1,0 +1,69 @@
+#!/usr/bin/env dotnet
+
+#:package MSBuild.StructuredLogger@2.3.154
+
+using Microsoft.Build.Logging.StructuredLogger;
+
+if (args.Length == 0)
+{
+    Console.Error.WriteLine("Usage: dotnet binlog-reader.cs <path-to-binlog> [...]");
+    return 1;
+}
+
+foreach (var path in args)
+{
+    if (!File.Exists(path))
+    {
+        Console.Error.WriteLine($"File not found: {path}");
+        continue;
+    }
+
+    Console.WriteLine($"\n=== {Path.GetFileName(path)} ===");
+
+    var build = BinaryLog.ReadBuild(path);
+
+    // Collect all Project nodes, gather their errors, then deduplicate by
+    // (ProjectFile, TargetFramework) — MSBuild evaluates each project multiple
+    // times across target batches, producing duplicate nodes.
+    var projects = new List<Project>();
+    build.VisitAllChildren<Project>(p => projects.Add(p));
+
+    // Inner builds have TargetFramework set; for single-targeted projects all
+    // nodes lack it, so fall back to the full list.
+    var innerBuilds = projects.Where(p => !string.IsNullOrEmpty(p.TargetFramework)).ToList();
+    var toShow = innerBuilds.Count > 0 ? innerBuilds : projects;
+
+    // Aggregate errors across all nodes for the same (file, TFM) pair.
+    var grouped = toShow
+        .GroupBy(p => (File: p.ProjectFile ?? p.Name, TFM: p.TargetFramework ?? ""))
+        .Select(g =>
+        {
+            var errors = new List<Error>();
+            foreach (var proj in g)
+            {
+                proj.VisitAllChildren<Error>(e => errors.Add(e));
+            }
+            return (g.Key.File, g.Key.TFM, Errors: errors.DistinctBy(e => (e.Code, e.Text, e.File, e.LineNumber)).ToList());
+        });
+
+    foreach (var byFile in grouped.GroupBy(x => x.File))
+    {
+        Console.WriteLine($"\n  {Path.GetFileName(byFile.Key)}");
+        foreach (var (_, tfm, errors) in byFile.OrderBy(x => x.TFM))
+        {
+            var label = string.IsNullOrEmpty(tfm) ? "(no TFM)" : tfm;
+            var status = errors.Count == 0 ? "✓" : "✗";
+            Console.WriteLine($"    {status} {label}");
+            foreach (var error in errors)
+            {
+                var location = string.IsNullOrEmpty(error.File) ? "" : $" ({Path.GetFileName(error.File)}:{error.LineNumber})";
+                Console.WriteLine($"        {error.Code}: {error.Text}{location}");
+            }
+        }
+    }
+
+    var overallStatus = build.Succeeded ? "succeeded" : "FAILED";
+    Console.WriteLine($"\n  Build {overallStatus}.");
+}
+
+return 0;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
 
   strazh:
@@ -7,7 +6,7 @@ services:
     container_name: strazh
     network_mode: host
     volumes:
-      - C:\src\github\strazh\SystemUnderTest:/dest
+      - ./SystemUnderTest:/dest
     environment:
       - c=neo4j:neo4j:strazhpass
       - p=/dest/Strazh.Tests.ProjectB/Strazh.Tests.ProjectB.csproj /dest/Strazh.Tests.ProjectA/Strazh.Tests.ProjectA.csproj
@@ -15,7 +14,7 @@ services:
       - neo4j
 
   neo4j:
-    image: neo4j:4.2.0
+    image: neo4j:2026.03.1
     container_name: strazh_neo4j
     restart: unless-stopped
     ports:
@@ -23,8 +22,8 @@ services:
       - 7687:7687
     environment:
       NEO4J_AUTH: neo4j/strazhpass
-      NEO4J_dbms_memory_pagecache_size: 1G
-      NEO4J_dbms.memory.heap.initial_size: 1G
-      NEO4J_dbms_memory_heap_max__size: 1G
-      NEO4JLABS_PLUGINS: "[\"apoc\",\"graph-data-science\"]"
+      NEO4J_server_memory_pagecache_size: 1G
+      NEO4J_server_memory_heap_initial__size: 1G
+      NEO4J_server_memory_heap_max__size: 1G
+      NEO4J_PLUGINS: "[\"apoc\",\"graph-data-science\"]"
       


### PR DESCRIPTION
## Summary

Fixes a graph-attribution bug visible in the live knowledge-graph: a single `Folder{name:"Core"}` node was `INCLUDED_IN` every downstream repo's folder (admin, analytics, delivery, espapi, personalize, personalize-classic, previews, litmus.net) instead of belonging only to `infra-dotnet-core`. Each project now resolves its own git root, so folder nodes for projects inside a submodule are attributed to the submodule's repository rather than whichever downstream solution was scanned. Submodule mount points are represented as a new `Folder` node `kind=Submodule` linked to both the host folder and the referenced `Repository`.

- `GitHelper.FindGitRoot` recognizes `.git` as a file (the marker used inside a checked-out submodule); `GetRepositoryName` follows the `gitdir:` pointer so paths inside a submodule resolve to the submodule's origin.
- New `GitModulesParser` for `.gitmodules`; `GitHelper.GetSubmodules` resolves relative URLs (`../foo.git`) against the host's origin via `System.Uri`. scp-style SSH (`git@host:path`) is round-tripped through `ssh://` since `Uri` doesn't grok scp-like syntax.
- `FolderNode` gains a `FolderKind` enum (`Regular` / `Submodule`); `Kind` is part of the PK so a `Submodule` mount-point and a same-named regular folder are distinct graph nodes. The `kind` Cypher property is only written when non-default.
- `Analyzer.GetSolutionAndRepositoryTriples`: each project resolves its own git root and repository; submodule projects attach to their own repo's root folder (a name derived from `owner/repo`'s last segment so PKs are stable across local clones); host repo's `.gitmodules` produces a `Folder(kind=Submodule)` at `<host>/<mountPath>` with `INCLUDED_IN` edges to the host folder and the referenced `Repository`.

End-to-end validation against the live `infra-dotnet-knowledge-graph` confirms `GetSubmodules` resolves `../infra-dotnet-core.git` to `LitmusEng/infra-dotnet-core` correctly for every downstream clone.

## Test plan

- [x] `GitModulesParserTests` — empty input, single/multi entries, comments, unknown keys, spacing tolerance, missing-field skipping.
- [x] `GitHelperTests` — `FindGitRoot` for both `.git`-directory and `.git`-file layouts; `GetRepositoryName` HTTPS / scp / submodule; `GetSubmodules` relative HTTPS, relative scp, double-dot org boundary, absolute HTTPS, absolute scp, no-`.gitmodules`.
- [x] `GitHelperIntegrationTests` — uses the real `git` CLI to init bare repos, add one as a submodule via a relative URL, clone `--recursive`, then asserts all of `FindGitRoot`, `GetRepositoryName`, and `GetSubmodules` against the actual checkout layout (`.git` file pointing into `.git/modules/<name>/`).
- [x] `FolderNodeTests` — Pk differs by Kind, Pk stable across instances, `Set` omits `kind` for Regular and writes `"Submodule"` for Submodule.
- [x] `AnalyzerSubmoduleTests` — copies `SystemUnderTest` into a temp dir with a fake `.git`/`.gitmodules`, runs `Analyze`, asserts the Submodule-kind mount folder + its `INCLUDED_IN` edges; also asserts no `Submodule`-kind folders are emitted when `.gitmodules` is absent.
- [x] All 30 tests pass; existing `AnalyzerTests` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)